### PR TITLE
Better thread shifting semantics on failure conditions

### DIFF
--- a/modules/core/src/test/scala/dev/profunktor/redis4cats/effect/JRFutureSpec.scala
+++ b/modules/core/src/test/scala/dev/profunktor/redis4cats/effect/JRFutureSpec.scala
@@ -45,4 +45,21 @@ class JRFutureSpec extends Redis4CatsAsyncFunSuite {
       .unsafeToFuture()
   }
 
+  test("it shifts back even when the CompletableFuture fails") {
+    val ioa =
+      JRFuture.fromCompletableFuture[IO, String] {
+        IO {
+          val jFuture = new CompletableFuture[String]()
+          jFuture.completeExceptionally(new RuntimeException("Purposely fail"))
+          jFuture
+        }
+      }
+
+    (ioa.attempt *> currentThread)
+      .flatMap { t =>
+        IO(assert(t.contains("scala-execution-context-global")))
+      }
+      .unsafeToFuture()
+  }
+
 }


### PR DESCRIPTION
- Use guarantee to ensure the computation shifts the thread pool even o…n failure conditions
- Write a test to verify this behavior
- `EmptyValue` cleanup

Addresses https://github.com/profunktor/redis4cats/pull/122