### PR TITLE
Unifying dependencies for the different Scala versions

### DIFF
--- a/modules/core/src/test/scala-2.12/dev/profunktor/redis4cats/testutils/Redis4CatsAsyncFunSuite.scala
+++ b/modules/core/src/test/scala-2.12/dev/profunktor/redis4cats/testutils/Redis4CatsAsyncFunSuite.scala
@@ -16,6 +16,6 @@
 
 package dev.profunktor.redis4cats.testutils
 
-import org.scalatest.AsyncFunSuite
+import org.scalatest.funsuite.AsyncFunSuite
 
 class Redis4CatsAsyncFunSuite extends AsyncFunSuite {}

--- a/modules/test-support/src/main/scala-2.12/dev/profunktor/redis4cats/testutils/Redis4CatsAsyncFunSuite.scala
+++ b/modules/test-support/src/main/scala-2.12/dev/profunktor/redis4cats/testutils/Redis4CatsAsyncFunSuite.scala
@@ -16,6 +16,6 @@
 
 package dev.profunktor.redis4cats.testutils
 
-import org.scalatest.AsyncFunSuite
+import org.scalatest.funsuite.AsyncFunSuite
 
 class Redis4CatsAsyncFunSuite extends AsyncFunSuite {}

--- a/modules/test-support/src/main/scala-2.12/dev/profunktor/redis4cats/testutils/Redis4CatsFunSuite.scala
+++ b/modules/test-support/src/main/scala-2.12/dev/profunktor/redis4cats/testutils/Redis4CatsFunSuite.scala
@@ -16,6 +16,6 @@
 
 package dev.profunktor.redis4cats.testutils
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class Redis4CatsFunSuite extends FunSuite {}
+class Redis4CatsFunSuite extends AnyFunSuite {}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,11 @@ import sbt._
 object Dependencies {
 
   object Versions {
+    val cats       = "2.0.0"
+    val catsEffect = "2.0.0"
+    val fs2        = "1.1.0-M2"
+    val log4cats   = "1.0.0-RC3"
+
     val lettuce    = "5.1.8.RELEASE"
     val logback    = "1.2.3"
 
@@ -10,66 +15,33 @@ object Dependencies {
     val kindProjector    = "0.10.3"
 
     val scalaCheck = "1.14.0"
-  }
-
-  object Versions212 {
-    val cats       = "1.6.1"
-    val catsEffect = "2.0.0"
-    val fs2        = "1.0.5"
-    val log4cats   = "0.3.0"
-
     val scalaTest  = "3.0.8"
-  }
-  
-  object Versions213 {
-    val cats       = "2.0.0-M4"
-    val catsEffect = "2.0.0-M4"
-    val fs2        = "1.1.0-M1"
-    val log4cats   = "0.4.0-M1"
-
-    val scalaTest  = "3.1.0-SNAP13"
   }
 
   object Libraries {
-    lazy val redisClient = "io.lettuce"    % "lettuce-core" % Versions.lettuce
+    def cats(artifact: String): ModuleID = "org.typelevel" %% s"cats-$artifact" % Versions.cats
+    def log4cats(artifact: String): ModuleID = "io.chrisdavenport" %% s"log4cats-$artifact" % Versions.log4cats
 
+    lazy val catsEffect  = "org.typelevel" %% "cats-effect" % Versions.catsEffect
+    lazy val fs2Core     = "co.fs2"        %% "fs2-core"    % Versions.fs2
+
+    lazy val log4CatsCore  = log4cats("core")
+    lazy val log4CatsSlf4j = log4cats("slf4j")
+
+    lazy val redisClient = "io.lettuce" % "lettuce-core" % Versions.lettuce
     lazy val logback = "ch.qos.logback" % "logback-classic" % Versions.logback
 
     // Compiler plugins
-    lazy val betterMonadicFor = "com.olegpy"     %% "better-monadic-for" % Versions.betterMonadicFor
+    lazy val betterMonadicFor = "com.olegpy"    %% "better-monadic-for" % Versions.betterMonadicFor
     lazy val kindProjector    = "org.typelevel" %% "kind-projector"     % Versions.kindProjector
 
     // Scala test libraries
-    lazy val scalaCheck  = "org.scalacheck" %% "scalacheck"   % Versions.scalaCheck
+    lazy val catsLaws      = cats("core")
+    lazy val catsTestKit   = cats("testkit")
+    lazy val catsTestKitST = "org.typelevel" %% "cats-testkit-scalatest" % "1.0.0-M1"
+
+    lazy val scalaTest   = "org.scalatest"  %% "scalatest"  % Versions.scalaTest
+    lazy val scalaCheck  = "org.scalacheck" %% "scalacheck" % Versions.scalaCheck
   }
 
-  object Libraries213 {
-    def log4cats(artifact: String): ModuleID = "io.chrisdavenport" %% s"log4cats-$artifact" % Versions213.log4cats
-
-    lazy val catsEffect  = "org.typelevel" %% "cats-effect" % Versions213.catsEffect
-    lazy val fs2Core     = "co.fs2"        %% "fs2-core"    % Versions213.fs2
-
-    lazy val log4CatsCore  = log4cats("core")
-    lazy val log4CatsSlf4j = log4cats("slf4j")
-
-    lazy val catsLaws    = "org.typelevel"  %% "cats-core"    % Versions213.cats
-    lazy val catsTestKit = "org.typelevel"  %% "cats-testkit" % Versions213.cats
-
-    lazy val scalaTest   = "org.scalatest"  %% "scalatest"    % Versions213.scalaTest
-  }
-
-  object Libraries212 {
-    def log4cats(artifact: String): ModuleID = "io.chrisdavenport" %% s"log4cats-$artifact" % Versions212.log4cats
-
-    lazy val catsEffect  = "org.typelevel" %% "cats-effect" % Versions212.catsEffect
-    lazy val fs2Core     = "co.fs2"        %% "fs2-core"    % Versions212.fs2
-
-    lazy val log4CatsCore  = log4cats("core")
-    lazy val log4CatsSlf4j = log4cats("slf4j")
-
-    lazy val catsLaws    = "org.typelevel"  %% "cats-core"    % Versions212.cats
-    lazy val catsTestKit = "org.typelevel"  %% "cats-testkit" % Versions212.cats
-
-    lazy val scalaTest   = "org.scalatest"  %% "scalatest"    % Versions212.scalaTest
-  }
 }


### PR DESCRIPTION
Closes #110 and #130 

There's still some more polishing to do but I'll leave that to future PRs before releasing a new version. i.e. there's no longer need to discriminate between Scala versions in Test Suites.

Also, I had to set `JAVA_OPTS="-XX:MaxMetaspaceSize=1024M"` to run the tests as I was getting OOM error as reported [here](https://github.com/sbt/sbt/issues/4686).