### PR TITLE
Add exists command support

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -26,7 +26,7 @@ trait StringCommands[F[_], K, V]
     with Increment[F, K, V]
     with Bits[F, K, V] {
   def del(key: K*): F[Unit]
-  def exists(key: K*): F[Long]
+  def exists(key: K*): F[Boolean]
   def expire(k: K, seconds: FiniteDuration): F[Unit]
 }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -26,6 +26,7 @@ trait StringCommands[F[_], K, V]
     with Increment[F, K, V]
     with Bits[F, K, V] {
   def del(key: K*): F[Unit]
+  def exists(key: K*): F[Long]
   def expire(k: K, seconds: FiniteDuration): F[Unit]
 }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -137,10 +137,10 @@ private[redis4cats] class BaseRedis[F[_]: ContextShift, K, V](
       async.flatMap(c => F.delay(c.del(key: _*)))
     }.void
 
-  def exists(key: K*): F[Long] =
+  def exists(key: K*): F[Boolean] =
     JRFuture {
       async.flatMap(c => F.delay(c.exists(key: _*)))
-    }.map(x => Long.box(x))
+    }.map(x => x == key.size.toLong)
 
   def expire(key: K, expiresIn: FiniteDuration): F[Unit] =
     JRFuture {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -137,6 +137,11 @@ private[redis4cats] class BaseRedis[F[_]: ContextShift, K, V](
       async.flatMap(c => F.delay(c.del(key: _*)))
     }.void
 
+  def exists(key: K*): F[Long] =
+    JRFuture {
+      async.flatMap(c => F.delay(c.exists(key: _*)))
+    }.map(x => Long.box(x))
+
   def expire(key: K, expiresIn: FiniteDuration): F[Unit] =
     JRFuture {
       async.flatMap(c => F.delay(c.expire(key, expiresIn.toSeconds)))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Fs2TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Fs2TestScenarios.scala
@@ -135,11 +135,11 @@ trait Fs2TestScenarios {
       x <- cmd.get(key)
       _ <- IO { assert(x.isEmpty) }
       exist1 <- cmd.exists(key)
-      _ <- IO { assert(exist1 == 0L) }
+      _ <- IO { assert(!exist1) }
       isSet1 <- cmd.setNx(key, "some value")
       _ <- IO { assert(isSet1) }
       exist2 <- cmd.exists(key)
-      _ <- IO { assert(exist2 == 1L) }
+      _ <- IO { assert(exist2) }
       y <- cmd.get(key)
       _ <- IO { assert(y.contains("some value")) }
       isSet2 <- cmd.setNx(key, "should not happen")
@@ -154,15 +154,17 @@ trait Fs2TestScenarios {
       _ <- IO { assert(val3.isEmpty) }
       isSet5 <- cmd.mSetNx(Map("multikey1" -> "someVal1", "multikey2" -> "someVal2"))
       _ <- IO { assert(!isSet5) }
-      exist3 <- cmd.exists(key, "multikey1", "_not_existing_key_")
-      _ <- IO { assert(exist3 == 2L) }
+      exist3 <- cmd.exists(key, "multikey1", "multikey2")
+      _ <- IO { assert(exist3) }
+      exist4 <- cmd.exists(key, "multikey1", "_not_existing_key_")
+      _ <- IO { assert(!exist4) }
       w <- cmd.get(key)
       _ <- IO { assert(w.contains("some value")) }
       _ <- cmd.del(key)
       z <- cmd.get(key)
       _ <- IO { assert(z.isEmpty) }
-      exist4 <- cmd.exists(key)
-      _ <- IO { assert(exist4 == 0L) }
+      exist5 <- cmd.exists(key)
+      _ <- IO { assert(!exist5) }
     } yield ()
   }
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Fs2TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Fs2TestScenarios.scala
@@ -134,8 +134,12 @@ trait Fs2TestScenarios {
     for {
       x <- cmd.get(key)
       _ <- IO { assert(x.isEmpty) }
+      exist1 <- cmd.exists(key)
+      _ <- IO { assert(exist1 == 0L) }
       isSet1 <- cmd.setNx(key, "some value")
       _ <- IO { assert(isSet1) }
+      exist2 <- cmd.exists(key)
+      _ <- IO { assert(exist2 == 1L) }
       y <- cmd.get(key)
       _ <- IO { assert(y.contains("some value")) }
       isSet2 <- cmd.setNx(key, "should not happen")
@@ -150,11 +154,15 @@ trait Fs2TestScenarios {
       _ <- IO { assert(val3.isEmpty) }
       isSet5 <- cmd.mSetNx(Map("multikey1" -> "someVal1", "multikey2" -> "someVal2"))
       _ <- IO { assert(!isSet5) }
+      exist3 <- cmd.exists(key, "multikey1", "_not_existing_key_")
+      _ <- IO { assert(exist3 == 2L) }
       w <- cmd.get(key)
       _ <- IO { assert(w.contains("some value")) }
       _ <- cmd.del(key)
       z <- cmd.get(key)
       _ <- IO { assert(z.isEmpty) }
+      exist4 <- cmd.exists(key)
+      _ <- IO { assert(exist4 == 0L) }
     } yield ()
   }
 


### PR DESCRIPTION
closes #151 

>We can split all key-related commands (`del`, `expire`, `exists`, etc.) to separate trait.