### PR TITLE
Upgrading to lettuce-5.2.0.RELEASE

### DIFF
--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisMasterReplica.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisMasterReplica.scala
@@ -41,7 +41,7 @@ object RedisMasterReplica {
           .fromCompletableFuture[F, StatefulRedisMasterReplicaConnection[K, V]] {
             Sync[F].delay { MasterReplica.connectAsync[K, V](client.underlying, codec.underlying, uris.asJava) }
           }
-          .map(LiveRedisMasterSlaveConnection.apply)
+          .map(LiveRedisMasterReplicaConnection.apply)
 
       readFrom.fold(connection)(rf => connection.flatMap(c => Sync[F].delay(c.underlying.setReadFrom(rf)) *> c.pure[F]))
     }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/domain.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/domain.scala
@@ -19,7 +19,7 @@ package dev.profunktor.redis4cats
 import io.lettuce.core.{ RedisClient => JRedisClient, ReadFrom => JReadFrom }
 import io.lettuce.core.cluster.{ RedisClusterClient => JClusterClient }
 import io.lettuce.core.codec.{ RedisCodec => JRedisCodec, StringCodec, ToByteBufEncoder }
-import io.lettuce.core.masterslave.StatefulRedisMasterSlaveConnection
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection
 
 object domain {
 
@@ -33,11 +33,11 @@ object domain {
   }
   case class LiveRedisClusterClient(underlying: JClusterClient) extends RedisClusterClient
 
-  trait RedisMasterSlaveConnection[K, V] {
-    def underlying: StatefulRedisMasterSlaveConnection[K, V]
+  trait RedisMasterReplicaConnection[K, V] {
+    def underlying: StatefulRedisMasterReplicaConnection[K, V]
   }
-  case class LiveRedisMasterSlaveConnection[K, V](underlying: StatefulRedisMasterSlaveConnection[K, V])
-      extends RedisMasterSlaveConnection[K, V]
+  case class LiveRedisMasterSlaveConnection[K, V](underlying: StatefulRedisMasterReplicaConnection[K, V])
+      extends RedisMasterReplicaConnection[K, V]
 
   trait RedisChannel[K] {
     def underlying: K
@@ -59,11 +59,11 @@ object domain {
   }
 
   object ReadFrom {
-    val Master          = JReadFrom.MASTER
-    val MasterPreferred = JReadFrom.MASTER_PREFERRED
-    val Nearest         = JReadFrom.NEAREST
-    val Slave           = JReadFrom.SLAVE
-    val SlavePreferred  = JReadFrom.SLAVE_PREFERRED
+    val Master           = JReadFrom.MASTER
+    val MasterPreferred  = JReadFrom.MASTER_PREFERRED
+    val Nearest          = JReadFrom.NEAREST
+    val Replica          = JReadFrom.REPLICA
+    val ReplicaPreferred = JReadFrom.REPLICA_PREFERRED
   }
 
 }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/domain.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/domain.scala
@@ -36,7 +36,7 @@ object domain {
   trait RedisMasterReplicaConnection[K, V] {
     def underlying: StatefulRedisMasterReplicaConnection[K, V]
   }
-  case class LiveRedisMasterSlaveConnection[K, V](underlying: StatefulRedisMasterReplicaConnection[K, V])
+  case class LiveRedisMasterReplicaConnection[K, V](underlying: StatefulRedisMasterReplicaConnection[K, V])
       extends RedisMasterReplicaConnection[K, V]
 
   trait RedisChannel[K] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -93,7 +93,7 @@ object Redis {
       uri: JRedisURI
   ): Resource[F, RedisCommands[F, K, V]] = {
     val (acquire, release) = acquireAndRelease(client, codec, uri)
-    Resource.make(acquire)(release).map(_.asInstanceOf[RedisCommands[F, K, V]])
+    Resource.make(acquire)(release).widen
   }
 
   def cluster[F[_]: Concurrent: ContextShift: Log, K, V](
@@ -101,7 +101,7 @@ object Redis {
       codec: RedisCodec[K, V]
   ): Resource[F, RedisCommands[F, K, V]] = {
     val (acquire, release) = acquireAndReleaseCluster(clusterClient, codec)
-    Resource.make(acquire)(release).map(_.asInstanceOf[RedisCommands[F, K, V]])
+    Resource.make(acquire)(release).widen
   }
 
   def clusterByNode[F[_]: Concurrent: ContextShift: Log, K, V](
@@ -110,13 +110,13 @@ object Redis {
       nodeId: NodeId
   ): Resource[F, RedisCommands[F, K, V]] = {
     val (acquire, release) = acquireAndReleaseClusterByNode(clusterClient, codec, nodeId)
-    Resource.make(acquire)(release).map(_.asInstanceOf[RedisCommands[F, K, V]])
+    Resource.make(acquire)(release).widen
   }
 
   def masterReplica[F[_]: Concurrent: ContextShift: Log, K, V](
       conn: RedisMasterReplicaConnection[K, V]
   ): F[RedisCommands[F, K, V]] =
-    new Redis[F, K, V](new RedisStatefulConnection(conn.underlying)).asInstanceOf[RedisCommands[F, K, V]].pure[F]
+    new Redis[F, K, V](new RedisStatefulConnection(conn.underlying)).pure[F].widen
 
 }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -116,8 +116,11 @@ object Redis {
   def masterReplica[F[_]: Concurrent: ContextShift: Log, K, V](
       conn: RedisMasterReplicaConnection[K, V]
   ): F[RedisCommands[F, K, V]] =
-    Sync[F].delay(new Redis[F, K, V](new RedisStatefulConnection(conn.underlying))).widen
-
+    Sync[F]
+      .delay {
+        new RedisStatefulConnection(conn.underlying)
+      }
+      .map(new Redis[F, K, V](_))
 }
 
 private[redis4cats] class BaseRedis[F[_]: ContextShift, K, V](

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -116,7 +116,7 @@ object Redis {
   def masterReplica[F[_]: Concurrent: ContextShift: Log, K, V](
       conn: RedisMasterReplicaConnection[K, V]
   ): F[RedisCommands[F, K, V]] =
-    new Redis[F, K, V](new RedisStatefulConnection(conn.underlying)).pure[F].widen
+    Sync[F].delay(new Redis[F, K, V](new RedisStatefulConnection(conn.underlying))).widen
 
 }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -113,8 +113,8 @@ object Redis {
     Resource.make(acquire)(release).map(_.asInstanceOf[RedisCommands[F, K, V]])
   }
 
-  def masterSlave[F[_]: Concurrent: ContextShift: Log, K, V](
-      conn: RedisMasterSlaveConnection[K, V]
+  def masterReplica[F[_]: Concurrent: ContextShift: Log, K, V](
+      conn: RedisMasterReplicaConnection[K, V]
   ): F[RedisCommands[F, K, V]] =
     new Redis[F, K, V](new RedisStatefulConnection(conn.underlying)).asInstanceOf[RedisCommands[F, K, V]].pure[F]
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
@@ -18,11 +18,11 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.domain.{ ReadFrom, RedisMasterSlaveConnection }
+import dev.profunktor.redis4cats.domain.{ ReadFrom, RedisMasterReplicaConnection }
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.interpreter.Redis
 
-object RedisMasterSlaveStringsDemo extends LoggerIOApp {
+object RedisMasterReplicaStringsDemo extends LoggerIOApp {
 
   import Demo._
 
@@ -32,14 +32,14 @@ object RedisMasterSlaveStringsDemo extends LoggerIOApp {
     val showResult: Option[String] => IO[Unit] =
       _.fold(putStrLn(s"Not found key: $usernameKey"))(s => putStrLn(s))
 
-    val connection: Resource[IO, RedisMasterSlaveConnection[String, String]] =
+    val connection: Resource[IO, RedisMasterReplicaConnection[String, String]] =
       Resource.liftF(RedisURI.make[IO](redisURI)).flatMap { uri =>
-        RedisMasterSlave[IO, String, String](stringCodec, uri)(Some(ReadFrom.MasterPreferred))
+        RedisMasterReplica[IO, String, String](stringCodec, uri)(Some(ReadFrom.MasterPreferred))
       }
 
     connection
       .use { conn =>
-        Redis.masterSlave[IO, String, String](conn).flatMap { cmd =>
+        Redis.masterReplica[IO, String, String](conn).flatMap { cmd =>
           for {
             x <- cmd.get(usernameKey)
             _ <- showResult(x)

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/interpreter/streams/Fs2Streaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/interpreter/streams/Fs2Streaming.scala
@@ -48,7 +48,7 @@ object RedisStream {
     Stream.bracket(acquire)(release).map(rs => new RedisStream(rs))
   }
 
-  def mkMasterSlaveConnection[F[_]: Concurrent: ContextShift: Log, K, V](
+  def mkMasterReplicaConnection[F[_]: Concurrent: ContextShift: Log, K, V](
       codec: RedisCodec[K, V],
       uris: JRedisURI*
   )(readFrom: Option[JReadFrom] = None): Stream[F, Streaming[Stream[F, ?], K, V]] =

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/interpreter/streams/Fs2Streaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/interpreter/streams/Fs2Streaming.scala
@@ -21,7 +21,7 @@ import cats.effect.concurrent.Ref
 import cats.instances.list._
 import cats.syntax.all._
 import dev.profunktor.redis4cats.algebra.Streaming
-import dev.profunktor.redis4cats.connection.RedisMasterSlave
+import dev.profunktor.redis4cats.connection.RedisMasterReplica
 import dev.profunktor.redis4cats.domain._
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log }
 import dev.profunktor.redis4cats.streams._
@@ -52,7 +52,7 @@ object RedisStream {
       codec: RedisCodec[K, V],
       uris: JRedisURI*
   )(readFrom: Option[JReadFrom] = None): Stream[F, Streaming[Stream[F, ?], K, V]] =
-    Stream.resource(RedisMasterSlave[F, K, V](codec, uris: _*)(readFrom)).map { conn =>
+    Stream.resource(RedisMasterReplica[F, K, V](codec, uris: _*)(readFrom)).map { conn =>
       new RedisStream(new RedisRawStreaming(conn.underlying))
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val fs2        = "2.0.1"
     val log4cats   = "1.0.0"
 
-    val lettuce    = "5.1.8.RELEASE"
+    val lettuce    = "5.2.0.RELEASE"
     val logback    = "1.2.3"
 
     val betterMonadicFor = "0.3.1"

--- a/site/src/main/tut/effects/index.md
+++ b/site/src/main/tut/effects/index.md
@@ -114,4 +114,4 @@ connection.use { conn =>
 }
 ```
 
-Find more information [here](https://github.com/lettuce-io/lettuce-core/wiki/Master-Slave#examples).
+Find more information [here](https://github.com/lettuce-io/lettuce-core/wiki/Master-Replica#examples).

--- a/site/src/main/tut/streams/streams.md
+++ b/site/src/main/tut/streams/streams.md
@@ -22,10 +22,10 @@ def mkStreamingConnection[F[_], K, V](
 ): Stream[F, Streaming[Stream[F, ?], K, V]]
 ```
 
-#### Master / Slave connection
+#### Master / Replica connection
 
 ```scala
-def mkMasterSlaveConnection[F[_], K, V](codec: RedisCodec[K, V], uris: JRedisURI*)(
+def mkMasterReplicaConnection[F[_], K, V](codec: RedisCodec[K, V], uris: JRedisURI*)(
   readFrom: Option[ReadFrom] = None): Stream[F, Streaming[Stream[F, ?], K, V]]
 ```
 


### PR DESCRIPTION
closes #145 

Renamed all `MasterSlave` stuff to `MasterReplica` as in Lettuce. 

We'll need to cut a new major version soon given that these are breaking changes.