### PR TITLE
Relaxing constraint on RedisURI.make

### DIFF
--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisURI.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisURI.scala
@@ -16,10 +16,10 @@
 
 package dev.profunktor.redis4cats.connection
 
-import cats.effect.Sync
+import cats.ApplicativeError
 import io.lettuce.core.{ RedisURI => JRedisURI }
 
 object RedisURI {
-  def make[F[_]: Sync](uri: => String): F[JRedisURI] =
-    Sync[F].delay(JRedisURI.create(uri))
+  def make[F[_]](uri: => String)(implicit F: ApplicativeError[F, Throwable]): F[JRedisURI] =
+    F.catchNonFatal(JRedisURI.create(uri))
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -56,8 +56,8 @@ object effects {
   }
   case class SetArgs(existence: Option[SetArg.Existence], ttl: Option[SetArg.Ttl])
   object SetArgs {
-    def apply(ex: SetArg.Existence): SetArgs = SetArgs(Some(ex), None)
-    def apply(ttl: SetArg.Ttl): SetArgs = SetArgs(None, Some(ttl))
+    def apply(ex: SetArg.Existence): SetArgs                  = SetArgs(Some(ex), None)
+    def apply(ttl: SetArg.Ttl): SetArgs                       = SetArgs(None, Some(ttl))
     def apply(ex: SetArg.Existence, ttl: SetArg.Ttl): SetArgs = SetArgs(Some(ex), Some(ttl))
   }
 }


### PR DESCRIPTION
As suggested by @tpolecat, using `catchNonFatal` instead of `delay`.