### PR TITLE
Make Transactions Semantically Correct

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -44,16 +44,20 @@ object effects {
   object SetArg {
     sealed trait Existence extends SetArg
     object Existence {
+
       /** Only set key if it does not exist */
       case object Nx extends Existence
+
       /** Only set key if it already exists */
       case object Xx extends Existence
     }
 
     sealed trait Ttl extends SetArg
     object Ttl {
+
       /** Set Expiration in Millis */
       case class Px(duration: FiniteDuration) extends Ttl
+
       /** Set Expiration in Seconds */
       case class Ex(duration: FiniteDuration) extends Ttl
     }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
@@ -24,6 +24,7 @@ import dev.profunktor.redis4cats.effect.Log
 
 object transactions {
 
+  /** Old System, Perhaps Deprecated */
   case class RedisTransaction[F[_]: Log: Sync, K, V](
       cmd: RedisCommands[F, K, V]
   ) {
@@ -35,5 +36,182 @@ object transactions {
           case (_, ExitCase.Canceled)  => cmd.discard *> Log[F].error("Transaction canceled")
         }
   }
+
+  private def transactionResource[F[_]: Log: Bracket[*[_], Throwable], K, V](cmd: RedisCommands[F, K, V]): Resource[F, Unit] = 
+    for {
+      _ <- Resource.liftF(Log[F].info("Transaction started"))
+      out <- Resource.makeCase(cmd.multi){
+        case (_, ExitCase.Completed) => cmd.exec *> Log[F].info("Transaction completed")
+        case (_, ExitCase.Error(e))  => 
+          cmd.discard *> Log[F].error(s"Transaction failed: ${e.getMessage}")
+        case (_, ExitCase.Canceled)  =>
+          cmd.discard *>  Log[F].error("Transaction canceled")
+      }
+    } yield out
+
+  private def safeFiber[F[_]: Concurrent, A](fa: F[A]): Resource[F, Fiber[F,A]] = 
+    Resource.makeCase(fa.start){
+      case (_, ExitCase.Completed) => Sync[F].unit
+      case (f, ExitCase.Error(_)) => f.cancel
+      case (f, ExitCase.Canceled) => f.cancel
+    }
+
+  /** This Can be expanded to arbitrary arity with shapeless or macros **/
+
+  def runTransaction[F[_]: Log: Concurrent, K, V, A](
+    fa: RedisCommands[F, K, V] => F[A]
+  )(cmd: RedisCommands[F, K, V]): F[A] = {
+    transactionResource(cmd) *>
+    safeFiber(fa(cmd))
+  }.use(_.pure[F])
+    .bracket(_.join)(_.cancel)
+
+  def runTransaction[F[_]: Log: Concurrent, K, V, A, B](
+    fa: RedisCommands[F, K, V] => F[A],
+    fb: RedisCommands[F, K, V] => F[B]
+  )(cmd: RedisCommands[F, K, V]): F[(A, B)] = {
+    transactionResource(cmd) *> 
+    (safeFiber(fa(cmd)), safeFiber(fb(cmd))).tupled
+  }.use(_.pure[F])
+    .bracket{case (fa, fb) => (fa.join, fb.join).tupled}{ case (fa, fb) => (fa.cancel, fb.cancel).tupled.void}
+
+  def runTransaction[F[_]: Log: Concurrent, K, V, A, B, C](
+    fa: RedisCommands[F, K, V] => F[A],
+    fb: RedisCommands[F, K, V] => F[B],
+    fc: RedisCommands[F, K, V] => F[C]
+  )(cmd: RedisCommands[F, K, V]): F[(A, B, C)] = {
+    transactionResource(cmd) *> 
+    (
+      safeFiber(fa(cmd)),
+      safeFiber(fb(cmd)),
+      safeFiber(fc(cmd))
+    ).tupled
+  }.use(_.pure[F])
+    .bracket{
+      case (fa, fb, fc) => (fa.join, fb.join, fc.join).tupled
+    }{ 
+      case (fa, fb, fc) => (fa.cancel, fb.cancel, fc.cancel).tupled.void
+    }
+
+  def runTransaction[F[_]: Log: Concurrent, K, V, A, B, C, D](
+    fa: RedisCommands[F, K, V] => F[A],
+    fb: RedisCommands[F, K, V] => F[B],
+    fc: RedisCommands[F, K, V] => F[C],
+    fd: RedisCommands[F, K, V] => F[D],
+  )(cmd: RedisCommands[F, K, V]): F[(A, B, C, D)] = {
+    transactionResource(cmd) *> 
+    (
+      safeFiber(fa(cmd)),
+      safeFiber(fb(cmd)),
+      safeFiber(fc(cmd)),
+      safeFiber(fd(cmd)),
+    ).tupled
+  }.use(_.pure[F])
+    .bracket{
+      case (fa, fb, fc, fd) => (fa.join, fb.join, fc.join, fd.join).tupled
+    }{ 
+      case (fa, fb, fc, fd) => (fa.cancel, fb.cancel, fc.cancel, fd.join).tupled.void
+    }
+
+  def runTransaction[F[_]: Log: Concurrent, K, V, A, B, C, D, E](
+    fa: RedisCommands[F, K, V] => F[A],
+    fb: RedisCommands[F, K, V] => F[B],
+    fc: RedisCommands[F, K, V] => F[C],
+    fd: RedisCommands[F, K, V] => F[D],
+    fe: RedisCommands[F, K, V] => F[E],
+  )(cmd: RedisCommands[F, K, V]): F[(A, B, C, D, E)] = {
+    transactionResource(cmd) *> 
+    (
+      safeFiber(fa(cmd)),
+      safeFiber(fb(cmd)),
+      safeFiber(fc(cmd)),
+      safeFiber(fd(cmd)),
+      safeFiber(fe(cmd)),
+    ).tupled
+  }.use(_.pure[F])
+    .bracket{
+      case (fa, fb, fc, fd, fe) => (fa.join, fb.join, fc.join, fd.join, fe.join).tupled
+    }{ 
+      case (fa, fb, fc, fd, fe) => (fa.cancel, fb.cancel, fc.cancel, fd.join, fe.join).tupled.void
+    }
+
+  def runTransaction[F[_]: Log: Concurrent, K, V, A, B, C, D, E, G](
+    fa: RedisCommands[F, K, V] => F[A],
+    fb: RedisCommands[F, K, V] => F[B],
+    fc: RedisCommands[F, K, V] => F[C],
+    fd: RedisCommands[F, K, V] => F[D],
+    fe: RedisCommands[F, K, V] => F[E],
+    fg: RedisCommands[F, K, V] => F[G],
+  )(cmd: RedisCommands[F, K, V]): F[(A, B, C, D, E, G)] = {
+    transactionResource(cmd) *> 
+    (
+      safeFiber(fa(cmd)),
+      safeFiber(fb(cmd)),
+      safeFiber(fc(cmd)),
+      safeFiber(fd(cmd)),
+      safeFiber(fe(cmd)),
+      safeFiber(fg(cmd)),
+    ).tupled
+  }.use(_.pure[F])
+    .bracket{
+      case (fa, fb, fc, fd, fe, fg) => (fa.join, fb.join, fc.join, fd.join, fe.join, fg.join).tupled
+    }{ 
+      case (fa, fb, fc, fd, fe, fg) => (fa.cancel, fb.cancel, fc.cancel, fd.cancel, fe.cancel, fg.cancel).tupled.void
+    }
+
+  def runTransaction[F[_]: Log: Concurrent, K, V, A, B, C, D, E, G, H](
+    fa: RedisCommands[F, K, V] => F[A],
+    fb: RedisCommands[F, K, V] => F[B],
+    fc: RedisCommands[F, K, V] => F[C],
+    fd: RedisCommands[F, K, V] => F[D],
+    fe: RedisCommands[F, K, V] => F[E],
+    fg: RedisCommands[F, K, V] => F[G],
+    fh: RedisCommands[F, K, V] => F[H],
+  )(cmd: RedisCommands[F, K, V]): F[(A, B, C, D, E, G, H)] = {
+    transactionResource(cmd) *> 
+    (
+      safeFiber(fa(cmd)),
+      safeFiber(fb(cmd)),
+      safeFiber(fc(cmd)),
+      safeFiber(fd(cmd)),
+      safeFiber(fe(cmd)),
+      safeFiber(fg(cmd)),
+      safeFiber(fh(cmd)),
+    ).tupled
+  }.use(_.pure[F])
+    .bracket{
+      case (fa, fb, fc, fd, fe, fg, fh) => (fa.join, fb.join, fc.join, fd.join, fe.join, fg.join, fh.join).tupled
+    }{ 
+      case (fa, fb, fc, fd, fe, fg, fh) => (fa.cancel, fb.cancel, fc.cancel, fd.cancel, fe.cancel, fg.cancel, fh.cancel).tupled.void
+    }
+
+  def runTransaction[F[_]: Log: Concurrent, K, V, A, B, C, D, E, G, H, I](
+    fa: RedisCommands[F, K, V] => F[A],
+    fb: RedisCommands[F, K, V] => F[B],
+    fc: RedisCommands[F, K, V] => F[C],
+    fd: RedisCommands[F, K, V] => F[D],
+    fe: RedisCommands[F, K, V] => F[E],
+    fg: RedisCommands[F, K, V] => F[G],
+    fh: RedisCommands[F, K, V] => F[H],
+    fi: RedisCommands[F, K, V] => F[I],
+  )(cmd: RedisCommands[F, K, V]): F[(A, B, C, D, E, G, H, I)] = {
+    transactionResource(cmd) *> 
+    (
+      safeFiber(fa(cmd)),
+      safeFiber(fb(cmd)),
+      safeFiber(fc(cmd)),
+      safeFiber(fd(cmd)),
+      safeFiber(fe(cmd)),
+      safeFiber(fg(cmd)),
+      safeFiber(fh(cmd)),
+      safeFiber(fi(cmd)),
+    ).tupled
+  }.use(_.pure[F])
+    .bracket{
+      case (fa, fb, fc, fd, fe, fg, fh, fi) => (fa.join, fb.join, fc.join, fd.join, fe.join, fg.join, fh.join, fi.join).tupled
+    }{ 
+      case (fa, fb, fc, fd, fe, fg, fh, fi) => (fa.cancel, fb.cancel, fc.cancel, fd.cancel, fe.cancel, fg.cancel, fh.cancel, fi.cancel).tupled.void
+    }
+
 
 }


### PR DESCRIPTION
## What this solves

- Currently Transactions Are Concurrently Sent and The Fibers Cannot Complete Until After the flush.
- This means that all of those fibers cannot be guarded to be cancelled correctly.
- Here we introduce an applicative syntax that takes a client, and appropriately forks and runs the actions. We can expand this to any HList of this form, which may be easier than doing this as we do here, which only exposes up to arity8

## What this doesn't solve

- `cmd.multi` starts a global transaction for the entire client, however this means that other concurrent calls will get dropped into this transaction without the users knowledge, and may cause transaction failure.
- Do we need a way to lock a client when these modes are entered?