### PR TITLE
Add liftK to RedisCommands

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/redis.scala
@@ -16,6 +16,8 @@
 
 package dev.profunktor.redis4cats.algebra
 
+import cats.effect.{ Concurrent, ContextShift }
+
 trait RedisCommands[F[_], K, V]
     extends StringCommands[F, K, V]
     with HashCommands[F, K, V]
@@ -27,4 +29,6 @@ trait RedisCommands[F[_], K, V]
     with ServerCommands[F, K]
     with TransactionalCommands[F, K]
     with PipelineCommands[F]
-    with KeyCommands[F, K]
+    with KeyCommands[F, K] {
+  def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V]
+}

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -127,6 +127,8 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
     val cluster: Boolean
 ) extends RedisCommands[F, K, V]
     with RedisConversionOps {
+  override def liftK[G[_]: Concurrent: ContextShift]: BaseRedis[G, K, V] =
+    new BaseRedis[G, K, V](conn.liftK[G], cluster)
 
   import dev.profunktor.redis4cats.JavaConversions._
 


### PR DESCRIPTION
This is required to be able to change the `F` of `RedisCommands` as the internal connection is not visible from outside (not held in a val of the class)