### PR TITLE
Add support for scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Redis client built on top of [Cats Effect](https://typelevel.org/cats-effect/), 
 - [Hashes API](https://redis.io/commands#hash): `hgetall`, `hset`, `hdel`, `hincrby`, etc.
 - [Keys API](https://redis.io/commands#generic): `del`, `expire`, `exists`, etc.
 - [Lists API](https://redis.io/commands#list): `rpush`, `lrange`, `lpop`, etc.
+- [Scripting API](https://redis.io/commands#scripting): `eval`, `evalsha`, etc.
 - [Server API](https://redis.io/commands#server): `flushall`, etc.
 - [Sets API](https://redis.io/commands#set): `sadd`, `scard`, `srem`, `spop`, etc.
 - [Sorted Sets API](https://redis.io/commands#sorted_set): `zcount`, `zcard`, `zrangebyscore`, `zrank`, etc.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/redis.scala
@@ -29,6 +29,7 @@ trait RedisCommands[F[_], K, V]
     with ServerCommands[F, K]
     with TransactionalCommands[F, K]
     with PipelineCommands[F]
+    with ScriptCommands[F, K, V]
     with KeyCommands[F, K] {
   def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -21,10 +21,10 @@ import dev.profunktor.redis4cats.effects.ScriptOutputType
 trait ScriptCommands[F[_], K, V] extends Scripting[F, K, V]
 
 trait Scripting[F[_], K, V] {
-  def eval[R](script: String, returnType: ScriptOutputType[V, R], keys: K*): F[R]
-  def eval[R](script: String, returnType: ScriptOutputType[V, R], keys: List[K], values: V*): F[R]
-  def evalSha[R](script: String, returnType: ScriptOutputType[V, R], keys: K*): F[R]
-  def evalSha[R](script: String, returnType: ScriptOutputType[V, R], keys: List[K], values: V*): F[R]
+  def eval[R](script: String, output: ScriptOutputType.Aux[V, R], keys: K*): F[R]
+  def evalWithValues[R](script: String, output: ScriptOutputType.Aux[V, R], keys: List[K], values: V*): F[R]
+  def evalSha[R](script: String, output: ScriptOutputType.Aux[V, R], keys: K*): F[R]
+  def evalShaWithValues[R](script: String, output: ScriptOutputType.Aux[V, R], keys: List[K], values: V*): F[R]
   // This unfortunately has to take a V instead of String due to a bug in lettuce:
   // https://github.com/lettuce-io/lettuce-core/issues/1010
   def scriptLoad(script: V): F[String]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -21,10 +21,10 @@ import dev.profunktor.redis4cats.effects.ScriptOutputType
 trait ScriptCommands[F[_], K, V] extends Scripting[F, K, V]
 
 trait Scripting[F[_], K, V] {
-  def eval[R](script: String, output: ScriptOutputType.Aux[V, R], keys: K*): F[R]
-  def evalWithValues[R](script: String, output: ScriptOutputType.Aux[V, R], keys: List[K], values: V*): F[R]
-  def evalSha[R](script: String, output: ScriptOutputType.Aux[V, R], keys: K*): F[R]
-  def evalShaWithValues[R](script: String, output: ScriptOutputType.Aux[V, R], keys: List[K], values: V*): F[R]
+  def eval[R: ScriptOutputType[V, *]](script: String, keys: K*): F[R]
+  def evalWithValues[R: ScriptOutputType[V, *]](script: String, keys: List[K], values: V*): F[R]
+  def evalSha[R: ScriptOutputType[V, *]](script: String, keys: K*): F[R]
+  def evalShaWithValues[R: ScriptOutputType[V, *]](script: String, keys: List[K], values: V*): F[R]
   // This unfortunately has to take a V instead of String due to a bug in lettuce:
   // https://github.com/lettuce-io/lettuce-core/issues/1010
   def scriptLoad(script: V): F[String]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -21,10 +21,10 @@ import dev.profunktor.redis4cats.effects.ScriptOutputType
 trait ScriptCommands[F[_], K, V] extends Scripting[F, K, V]
 
 trait Scripting[F[_], K, V] {
-  def eval(script: String, returnType: ScriptOutputType, keys: K*): F[returnType.Return[V]]
-  def eval(script: String, returnType: ScriptOutputType, keys: List[K], values: V*): F[returnType.Return[V]]
-  def evalSha(script: String, returnType: ScriptOutputType, keys: K*): F[returnType.Return[V]]
-  def evalSha(script: String, returnType: ScriptOutputType, keys: List[K], values: V*): F[returnType.Return[V]]
+  def eval[R](script: String, returnType: ScriptOutputType[V, R], keys: K*): F[R]
+  def eval[R](script: String, returnType: ScriptOutputType[V, R], keys: List[K], values: V*): F[R]
+  def evalSha[R](script: String, returnType: ScriptOutputType[V, R], keys: K*): F[R]
+  def evalSha[R](script: String, returnType: ScriptOutputType[V, R], keys: List[K], values: V*): F[R]
   // This unfortunately has to take a V instead of String due to a bug in lettuce:
   // https://github.com/lettuce-io/lettuce-core/issues/1010
   def scriptLoad(script: V): F[String]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -21,10 +21,14 @@ import dev.profunktor.redis4cats.effects.ScriptOutputType
 trait ScriptCommands[F[_], K, V] extends Scripting[F, K, V]
 
 trait Scripting[F[_], K, V] {
-  def eval[R: ScriptOutputType[V, *]](script: String, keys: K*): F[R]
-  def evalWithValues[R: ScriptOutputType[V, *]](script: String, keys: List[K], values: V*): F[R]
-  def evalSha[R: ScriptOutputType[V, *]](script: String, keys: K*): F[R]
-  def evalShaWithValues[R: ScriptOutputType[V, *]](script: String, keys: List[K], values: V*): F[R]
+  // these methods don't use varargs as they cause problems with type inference, see:
+  // https://github.com/scala/bug/issues/11488
+  def eval(script: String, output: ScriptOutputType[V]): F[output.R]
+  def evalWithKeys(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R]
+  def evalWithKeysAndValues(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R]
+  def evalSha(script: String, output: ScriptOutputType[V]): F[output.R]
+  def evalShaWithKeys(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R]
+  def evalShaWithKeysAndValues(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R]
   // This unfortunately has to take a V instead of String due to a bug in lettuce:
   // https://github.com/lettuce-io/lettuce-core/issues/1010
   def scriptLoad(script: V): F[String]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -24,11 +24,11 @@ trait Scripting[F[_], K, V] {
   // these methods don't use varargs as they cause problems with type inference, see:
   // https://github.com/scala/bug/issues/11488
   def eval(script: String, output: ScriptOutputType[V]): F[output.R]
-  def evalWithKeys(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R]
-  def evalWithKeysAndValues(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R]
+  def eval(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R]
+  def eval(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R]
   def evalSha(script: String, output: ScriptOutputType[V]): F[output.R]
-  def evalShaWithKeys(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R]
-  def evalShaWithKeysAndValues(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R]
+  def evalSha(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R]
+  def evalSha(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R]
   // This unfortunately has to take a V instead of String due to a bug in lettuce:
   // https://github.com/lettuce-io/lettuce-core/issues/1010
   def scriptLoad(script: V): F[String]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018-2019 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats.algebra
+
+import dev.profunktor.redis4cats.effects.ScriptOutputType
+
+trait ScriptCommands[F[_], K, V] extends Scripting[F, K, V]
+
+trait Scripting[F[_], K, V] {
+  def eval(script: String, returnType: ScriptOutputType, keys: K*): F[returnType.Return[V]]
+  def eval(script: String, returnType: ScriptOutputType, keys: List[K], values: V*)(
+      implicit ev: K <:< Object
+  ): F[returnType.Return[V]]
+  def evalSha(script: String, returnType: ScriptOutputType, keys: K*): F[returnType.Return[V]]
+  def evalSha(script: String, returnType: ScriptOutputType, keys: List[K], values: V*)(
+      implicit ev: K <:< Object
+  ): F[returnType.Return[V]]
+  // This unfortunately has to take a V instead of String due to a bug in lettuce:
+  // https://github.com/lettuce-io/lettuce-core/issues/1010
+  def scriptLoad(script: V): F[String]
+  def scriptExists(digests: String*): F[List[Boolean]]
+  def scriptFlush: F[Unit]
+}

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -22,13 +22,9 @@ trait ScriptCommands[F[_], K, V] extends Scripting[F, K, V]
 
 trait Scripting[F[_], K, V] {
   def eval(script: String, returnType: ScriptOutputType, keys: K*): F[returnType.Return[V]]
-  def eval(script: String, returnType: ScriptOutputType, keys: List[K], values: V*)(
-      implicit ev: K <:< Object
-  ): F[returnType.Return[V]]
+  def eval(script: String, returnType: ScriptOutputType, keys: List[K], values: V*): F[returnType.Return[V]]
   def evalSha(script: String, returnType: ScriptOutputType, keys: K*): F[returnType.Return[V]]
-  def evalSha(script: String, returnType: ScriptOutputType, keys: List[K], values: V*)(
-      implicit ev: K <:< Object
-  ): F[returnType.Return[V]]
+  def evalSha(script: String, returnType: ScriptOutputType, keys: List[K], values: V*): F[returnType.Return[V]]
   // This unfortunately has to take a V instead of String due to a bug in lettuce:
   // https://github.com/lettuce-io/lettuce-core/issues/1010
   def scriptLoad(script: V): F[String]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -40,7 +40,7 @@ object effects {
   final case class ZRange[V](start: V, end: V)
   final case class RangeLimit(offset: Long, count: Long)
 
-  sealed trait ScriptOutputType[V, R] {
+  sealed trait ScriptOutputType[-V, +R] {
     private[redis4cats] type Underlying[U]
     private[redis4cats] val outputType: JScriptOutputType
     private[redis4cats] def convert[U](in: Underlying[U]): R
@@ -74,7 +74,7 @@ object effects {
     }
 
     def Status[V]: ScriptOutputType[V, Unit] = new ScriptOutputType[V, Unit] {
-      private[redis4cats] type Underlying[U] = String
+      private[redis4cats] type Underlying[_] = String
       override private[redis4cats] val outputType                   = JScriptOutputType.STATUS
       override private[redis4cats] def convert[_](in: String): Unit = ()
     }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -640,14 +640,15 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
 
   override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit): F[Set[V]] =
     JRFuture {
-      async.flatMap(c => F.delay(c.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit))
+      async.flatMap(
+        c => F.delay(c.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit))
       )
     }.map(_.asScala.toSet)
 
   override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, args: GeoArgs): F[List[GeoRadiusResult[V]]] =
     JRFuture {
-      async.flatMap(c =>
-        F.delay(c.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit, args))
+      async.flatMap(
+        c => F.delay(c.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit, args))
       )
     }.map(_.asScala.toList.map(_.asGeoRadiusResult))
 
@@ -813,8 +814,8 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
     JRFuture {
       limit match {
         case Some(x) =>
-          async.flatMap(c =>
-            F.delay(c.zrangebylex(key, JRange.create[V](range.start, range.end), JLimit.create(x.offset, x.count)))
+          async.flatMap(
+            c => F.delay(c.zrangebylex(key, JRange.create[V](range.start, range.end), JLimit.create(x.offset, x.count)))
           )
         case None => async.flatMap(c => F.delay(c.zrangebylex(key, JRange.create[V](range.start, range.end))))
       }
@@ -837,8 +838,8 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
     JRFuture {
       limit match {
         case Some(x) =>
-          async.flatMap(c =>
-            F.delay(c.zrangebyscoreWithScores(key, range.asJavaRange, JLimit.create(x.offset, x.count)))
+          async.flatMap(
+            c => F.delay(c.zrangebyscoreWithScores(key, range.asJavaRange, JLimit.create(x.offset, x.count)))
           )
         case None => async.flatMap(c => F.delay(c.zrangebyscoreWithScores(key, range.asJavaRange)))
       }
@@ -863,8 +864,9 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
     JRFuture {
       limit match {
         case Some(x) =>
-          async.flatMap(c =>
-            F.delay(c.zrevrangebylex(key, JRange.create[V](range.start, range.end), JLimit.create(x.offset, x.count)))
+          async.flatMap(
+            c =>
+              F.delay(c.zrevrangebylex(key, JRange.create[V](range.start, range.end), JLimit.create(x.offset, x.count)))
           )
         case None => async.flatMap(c => F.delay(c.zrevrangebylex(key, JRange.create[V](range.start, range.end))))
       }
@@ -887,8 +889,8 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
     JRFuture {
       limit match {
         case Some(x) =>
-          async.flatMap(c =>
-            F.delay(c.zrangebyscoreWithScores(key, range.asJavaRange, JLimit.create(x.offset, x.count)))
+          async.flatMap(
+            c => F.delay(c.zrangebyscoreWithScores(key, range.asJavaRange, JLimit.create(x.offset, x.count)))
           )
         case None => async.flatMap(c => F.delay(c.zrangebyscoreWithScores(key, range.asJavaRange)))
       }
@@ -934,14 +936,15 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
   override def info: F[Map[String, String]] =
     JRFuture {
       async.flatMap(c => F.delay(c.info))
-    }.flatMap(info =>
-      F.delay(
-        info
-          .split("\\r?\\n")
-          .toList
-          .map(_.split(":", 2).toList)
-          .collect { case k :: v :: Nil => (k, v) }
-          .toMap
+    }.flatMap(
+      info =>
+        F.delay(
+          info
+            .split("\\r?\\n")
+            .toList
+            .map(_.split(":", 2).toList)
+            .collect { case k :: v :: Nil => (k, v) }
+            .toMap
       )
     )
 
@@ -960,53 +963,49 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       async.flatMap(c => F.delay(c.slowlogLen))
     }.map(Long.unbox)
 
-  override def eval[R](script: String, output: ScriptOutputType.Aux[V, R], keys: K*): F[R] =
+  override def eval[R](script: String, keys: K*)(implicit output: ScriptOutputType[V, R]): F[R] =
     JRFuture {
-      async.flatMap(c => F.delay(c.eval[output.Underlying[V]](script, output.outputType, keys: _*)))
+      async.flatMap(c => F.delay(c.eval[output.Underlying](script, output.outputType, keys: _*)))
     }.map(r => output.convert(r))
 
-  override def evalWithValues[R](
-      script: String,
-      output: ScriptOutputType.Aux[V, R],
-      keys: List[K],
-      values: V*
+  override def evalWithValues[R](script: String, keys: List[K], values: V*)(
+      implicit output: ScriptOutputType[V, R]
   ): F[R] =
     JRFuture {
-      async.flatMap(c =>
-        F.delay(
-          c.eval[output.Underlying[V]](
-            script,
-            output.outputType,
-            // The Object requirement comes from the limitations of Java Generics. It is safe to assume K <: Object as
-            // the underlying JRedisCodec would also only support K <: Object.
-            keys.asInstanceOf[List[K with Object]].toArray,
-            values: _*
-          )
+      async.flatMap(
+        c =>
+          F.delay(
+            c.eval[output.Underlying](
+              script,
+              output.outputType,
+              // The Object requirement comes from the limitations of Java Generics. It is safe to assume K <: Object as
+              // the underlying JRedisCodec would also only support K <: Object.
+              keys.asInstanceOf[List[K with Object]].toArray,
+              values: _*
+            )
         )
       )
     }.map(output.convert(_))
 
-  override def evalSha[R](script: String, output: ScriptOutputType.Aux[V, R], keys: K*): F[R] =
+  override def evalSha[R](script: String, keys: K*)(implicit output: ScriptOutputType[V, R]): F[R] =
     JRFuture {
-      async.flatMap(c => F.delay(c.evalsha[output.Underlying[V]](script, output.outputType, keys: _*)))
+      async.flatMap(c => F.delay(c.evalsha[output.Underlying](script, output.outputType, keys: _*)))
     }.map(output.convert(_))
 
-  override def evalShaWithValues[R](
-      script: String,
-      output: ScriptOutputType.Aux[V, R],
-      keys: List[K],
-      values: V*
+  override def evalShaWithValues[R](script: String, keys: List[K], values: V*)(
+      implicit output: ScriptOutputType[V, R]
   ): F[R] =
     JRFuture {
-      async.flatMap(c =>
-        F.delay(
-          c.evalsha[output.Underlying[V]](
-            script,
-            output.outputType,
-            // see comment in eval above
-            keys.asInstanceOf[List[K with Object]].toArray,
-            values: _*
-          )
+      async.flatMap(
+        c =>
+          F.delay(
+            c.evalsha[output.Underlying](
+              script,
+              output.outputType,
+              // see comment in eval above
+              keys.asInstanceOf[List[K with Object]].toArray,
+              values: _*
+            )
         )
       )
     }.map(output.convert(_))

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -960,12 +960,12 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       async.flatMap(c => F.delay(c.slowlogLen))
     }.map(Long.unbox)
 
-  override def eval(script: String, returnType: ScriptOutputType, keys: K*): F[returnType.Return[V]] =
+  override def eval[R](script: String, returnType: ScriptOutputType[V, R], keys: K*): F[R] =
     JRFuture {
       async.flatMap(c => F.delay(c.eval[returnType.Underlying[V]](script, returnType.outputType, keys: _*)))
-    }.map(returnType.convert(_))
+    }.map(r => returnType.convert(r))
 
-  override def eval(script: String, returnType: ScriptOutputType, keys: List[K], values: V*): F[returnType.Return[V]] =
+  override def eval[R](script: String, returnType: ScriptOutputType[V, R], keys: List[K], values: V*): F[R] =
     JRFuture {
       async.flatMap(c =>
         F.delay(
@@ -981,17 +981,12 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       )
     }.map(returnType.convert(_))
 
-  override def evalSha(script: String, returnType: ScriptOutputType, keys: K*): F[returnType.Return[V]] =
+  override def evalSha[R](script: String, returnType: ScriptOutputType[V, R], keys: K*): F[R] =
     JRFuture {
       async.flatMap(c => F.delay(c.evalsha[returnType.Underlying[V]](script, returnType.outputType, keys: _*)))
     }.map(returnType.convert(_))
 
-  override def evalSha(
-      script: String,
-      returnType: ScriptOutputType,
-      keys: List[K],
-      values: V*
-  ): F[returnType.Return[V]] =
+  override def evalSha[R](script: String, returnType: ScriptOutputType[V, R], keys: List[K], values: V*): F[R] =
     JRFuture {
       async.flatMap(c =>
         F.delay(

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -965,7 +965,7 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       async.flatMap(c => F.delay(c.eval[output.Underlying](script, output.outputType)))
     }.map(r => output.convert(r))
 
-  override def evalWithKeys(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R] =
+  override def eval(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R] =
     JRFuture {
       async.flatMap(c =>
         F.delay(
@@ -980,19 +980,14 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       )
     }.map(output.convert(_))
 
-  override def evalWithKeysAndValues(
-      script: String,
-      output: ScriptOutputType[V],
-      keys: List[K],
-      values: List[V]
-  ): F[output.R] =
+  override def eval(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R] =
     JRFuture {
       async.flatMap(c =>
         F.delay(
           c.eval[output.Underlying](
             script,
             output.outputType,
-            // see comment in evalWithKeys above
+            // see comment in eval above
             keys.asInstanceOf[Seq[K with Object]].toArray,
             values: _*
           )
@@ -1005,33 +1000,28 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       async.flatMap(c => F.delay(c.evalsha[output.Underlying](script, output.outputType)))
     }.map(output.convert(_))
 
-  override def evalShaWithKeys(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R] =
+  override def evalSha(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R] =
     JRFuture {
       async.flatMap(c =>
         F.delay(
           c.evalsha[output.Underlying](
             script,
             output.outputType,
-            // see comment in evalWithKeys above
+            // see comment in eval above
             keys.asInstanceOf[Seq[K with Object]].toArray
           )
         )
       )
     }.map(output.convert(_))
 
-  override def evalShaWithKeysAndValues(
-      script: String,
-      output: ScriptOutputType[V],
-      keys: List[K],
-      values: List[V]
-  ): F[output.R] =
+  override def evalSha(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R] =
     JRFuture {
       async.flatMap(c =>
         F.delay(
           c.evalsha[output.Underlying](
             script,
             output.outputType,
-            // see comment in evalWithKeys above
+            // see comment in eval above
             keys.asInstanceOf[Seq[K with Object]].toArray,
             values: _*
           )

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -965,15 +965,15 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       async.flatMap(c => F.delay(c.eval[returnType.Underlying[V]](script, returnType.outputType, keys: _*)))
     }.map(returnType.convert(_))
 
-  override def eval(script: String, returnType: ScriptOutputType, keys: List[K], values: V*)(
-      implicit ev: K <:< Object
-  ): F[returnType.Return[V]] =
+  override def eval(script: String, returnType: ScriptOutputType, keys: List[K], values: V*): F[returnType.Return[V]] =
     JRFuture {
       async.flatMap(c =>
         F.delay(
           c.eval[returnType.Underlying[V]](
             script,
             returnType.outputType,
+            // The Object requirement comes from the limitations of Java Generics. It is safe to assume K <: Object as
+            // the underlying JRedisCodec would also only support K <: Object.
             keys.asInstanceOf[List[K with Object]].toArray,
             values: _*
           )
@@ -986,8 +986,11 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       async.flatMap(c => F.delay(c.evalsha[returnType.Underlying[V]](script, returnType.outputType, keys: _*)))
     }.map(returnType.convert(_))
 
-  override def evalSha(script: String, returnType: ScriptOutputType, keys: List[K], values: V*)(
-      implicit ev: K <:< Object
+  override def evalSha(
+      script: String,
+      returnType: ScriptOutputType,
+      keys: List[K],
+      values: V*
   ): F[returnType.Return[V]] =
     JRFuture {
       async.flatMap(c =>
@@ -995,6 +998,7 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
           c.evalsha[returnType.Underlying[V]](
             script,
             returnType.outputType,
+            // see comment in eval above
             keys.asInstanceOf[List[K with Object]].toArray,
             values: _*
           )

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -38,9 +38,9 @@ object RedisScriptsDemo extends LoggerIOApp {
     commandsApi
       .use { cmd =>
         for {
-          greeting <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
+          greeting: String <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
           _ <- putStrLn(s"Greetings from Lua: $greeting")
-          fortyTwo <- cmd.eval("return 42", ScriptOutputType.Integer)
+          fortyTwo: Long <- cmd.eval("return 42", ScriptOutputType.Integer)
           _ <- putStrLn(s"Answer to the Ultimate Question of Life, the Universe, and Everything: $fortyTwo")
           list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi, Nil, "have", "fun")
           _ <- putStrLn(s"We can even return lists: $list")

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -20,7 +20,6 @@ import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.ScriptCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.effects.ScriptOutputType
 import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisScriptsDemo extends LoggerIOApp {
@@ -38,13 +37,12 @@ object RedisScriptsDemo extends LoggerIOApp {
     commandsApi
       .use { cmd =>
         for {
-          greeting: String <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
+          greeting: String <- cmd.eval[String]("return 'Hello World'")
           _ <- putStrLn(s"Greetings from Lua: $greeting")
-          fortyTwo: Long <- cmd.eval("return 42", ScriptOutputType.Integer)
+          fortyTwo: Long <- cmd.eval[Long]("return 42")
           _ <- putStrLn(s"Answer to the Ultimate Question of Life, the Universe, and Everything: $fortyTwo")
-          list <- cmd.evalWithValues(
+          list <- cmd.evalWithValues[List[String]](
                    "return {'Let', 'us', ARGV[1], ARGV[2]}",
-                   ScriptOutputType.Multi,
                    Nil,
                    "have",
                    "fun"
@@ -54,7 +52,7 @@ object RedisScriptsDemo extends LoggerIOApp {
           List(exists) <- cmd.scriptExists(shaRandom)
           _ <- putStrLn(s"Script is cached on Redis: $exists")
           // seeding the RNG with 7
-          random <- cmd.evalShaWithValues(shaRandom, ScriptOutputType.Integer, Nil, "7")
+          random <- cmd.evalShaWithValues[Long](shaRandom, Nil, "7")
           _ <- putStrLn(s"Execution of cached script returns a pseudo-random number: $random")
           () <- cmd.scriptFlush
           _ <- putStrLn("Flushed all cached scripts!")

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018-2019 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats
+
+import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.algebra.ScriptCommands
+import dev.profunktor.redis4cats.connection._
+import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effects.ScriptOutputType
+import dev.profunktor.redis4cats.interpreter.Redis
+
+object RedisScriptsDemo extends LoggerIOApp {
+
+  import Demo._
+
+  def program(implicit log: Log[IO]): IO[Unit] = {
+    val commandsApi: Resource[IO, ScriptCommands[IO, String, String]] =
+      for {
+        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
+        client <- RedisClient[IO](uri)
+        redis <- Redis[IO, String, String](client, stringCodec)
+      } yield redis
+
+    commandsApi
+      .use { cmd =>
+        for {
+          greeting <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
+          _ <- putStrLn(s"Greetings from Lua: $greeting")
+          fortyTwo <- cmd.eval("return 42", ScriptOutputType.Integer)
+          _ <- putStrLn(s"Answer to the Ultimate Question of Life, the Universe, and Everything: $fortyTwo")
+          list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi, Nil, "have", "fun")
+          _ <- putStrLn(s"We can even return lists: $list")
+          shaRandom <- cmd.scriptLoad("math.randomseed(tonumber(ARGV[1])); return math.random() * 1000")
+          List(exists) <- cmd.scriptExists(shaRandom)
+          _ <- putStrLn(s"Script is cached on Redis: $exists")
+          // seeding the RNG with 7
+          random <- cmd.evalSha(shaRandom, ScriptOutputType.Integer, Nil, "7")
+          _ <- putStrLn(s"Execution of cached script returns a pseudo-random number: $random")
+          () <- cmd.scriptFlush
+          _ <- putStrLn("Flushed all cached scripts!")
+          List(exists2) <- cmd.scriptExists(shaRandom)
+          _ <- putStrLn(s"Script is still cached on Redis: $exists2")
+        } yield ()
+      }
+  }
+
+}

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -42,7 +42,7 @@ object RedisScriptsDemo extends LoggerIOApp {
           _ <- putStrLn(s"Greetings from Lua: $greeting")
           fortyTwo: Long <- cmd.eval("return 42", ScriptOutputType.Integer)
           _ <- putStrLn(s"Answer to the Ultimate Question of Life, the Universe, and Everything: $fortyTwo")
-          list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi, Nil, "have", "fun")
+          list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi[String], Nil, "have", "fun")
           _ <- putStrLn(s"We can even return lists: $list")
           shaRandom <- cmd.scriptLoad("math.randomseed(tonumber(ARGV[1])); return math.random() * 1000")
           List(exists) <- cmd.scriptExists(shaRandom)

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -14,12 +14,61 @@
  * limitations under the License.
  */
 
+///*
+// * Copyright 2018-2019 ProfunKtor
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+/*
+ * Copyright 2018-2019 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2018-2019 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.ScriptCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effects.ScriptOutputType
 import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisScriptsDemo extends LoggerIOApp {
@@ -37,22 +86,22 @@ object RedisScriptsDemo extends LoggerIOApp {
     commandsApi
       .use { cmd =>
         for {
-          greeting: String <- cmd.eval[String]("return 'Hello World'")
+          greeting <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
           _ <- putStrLn(s"Greetings from Lua: $greeting")
-          fortyTwo: Long <- cmd.eval[Long]("return 42")
+          fortyTwo <- cmd.eval("return 42", ScriptOutputType.Integer)
           _ <- putStrLn(s"Answer to the Ultimate Question of Life, the Universe, and Everything: $fortyTwo")
-          list <- cmd.evalWithValues[List[String]](
+          list <- cmd.evalWithKeysAndValues(
                    "return {'Let', 'us', ARGV[1], ARGV[2]}",
+                   ScriptOutputType.Multi,
                    Nil,
-                   "have",
-                   "fun"
+                   List("have", "fun")
                  )
           _ <- putStrLn(s"We can even return lists: $list")
           shaRandom <- cmd.scriptLoad("math.randomseed(tonumber(ARGV[1])); return math.random() * 1000")
           List(exists) <- cmd.scriptExists(shaRandom)
           _ <- putStrLn(s"Script is cached on Redis: $exists")
           // seeding the RNG with 7
-          random <- cmd.evalShaWithValues[Long](shaRandom, Nil, "7")
+          random <- cmd.evalShaWithKeysAndValues(shaRandom, ScriptOutputType.Integer, Nil, List("7"))
           _ <- putStrLn(s"Execution of cached script returns a pseudo-random number: $random")
           () <- cmd.scriptFlush
           _ <- putStrLn("Flushed all cached scripts!")

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -14,54 +14,6 @@
  * limitations under the License.
  */
 
-///*
-// * Copyright 2018-2019 ProfunKtor
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
-/*
- * Copyright 2018-2019 ProfunKtor
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2018-2019 ProfunKtor
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
@@ -90,7 +42,7 @@ object RedisScriptsDemo extends LoggerIOApp {
           _ <- putStrLn(s"Greetings from Lua: $greeting")
           fortyTwo <- cmd.eval("return 42", ScriptOutputType.Integer)
           _ <- putStrLn(s"Answer to the Ultimate Question of Life, the Universe, and Everything: $fortyTwo")
-          list <- cmd.evalWithKeysAndValues(
+          list <- cmd.eval(
                    "return {'Let', 'us', ARGV[1], ARGV[2]}",
                    ScriptOutputType.Multi,
                    Nil,
@@ -101,7 +53,7 @@ object RedisScriptsDemo extends LoggerIOApp {
           List(exists) <- cmd.scriptExists(shaRandom)
           _ <- putStrLn(s"Script is cached on Redis: $exists")
           // seeding the RNG with 7
-          random <- cmd.evalShaWithKeysAndValues(shaRandom, ScriptOutputType.Integer, Nil, List("7"))
+          random <- cmd.evalSha(shaRandom, ScriptOutputType.Integer, Nil, List("7"))
           _ <- putStrLn(s"Execution of cached script returns a pseudo-random number: $random")
           () <- cmd.scriptFlush
           _ <- putStrLn("Flushed all cached scripts!")

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -42,13 +42,19 @@ object RedisScriptsDemo extends LoggerIOApp {
           _ <- putStrLn(s"Greetings from Lua: $greeting")
           fortyTwo: Long <- cmd.eval("return 42", ScriptOutputType.Integer)
           _ <- putStrLn(s"Answer to the Ultimate Question of Life, the Universe, and Everything: $fortyTwo")
-          list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi[String], Nil, "have", "fun")
+          list <- cmd.evalWithValues(
+                   "return {'Let', 'us', ARGV[1], ARGV[2]}",
+                   ScriptOutputType.Multi,
+                   Nil,
+                   "have",
+                   "fun"
+                 )
           _ <- putStrLn(s"We can even return lists: $list")
           shaRandom <- cmd.scriptLoad("math.randomseed(tonumber(ARGV[1])); return math.random() * 1000")
           List(exists) <- cmd.scriptExists(shaRandom)
           _ <- putStrLn(s"Script is cached on Redis: $exists")
           // seeding the RNG with 7
-          random <- cmd.evalSha(shaRandom, ScriptOutputType.Integer, Nil, "7")
+          random <- cmd.evalShaWithValues(shaRandom, ScriptOutputType.Integer, Nil, "7")
           _ <- putStrLn(s"Execution of cached script returns a pseudo-random number: $random")
           () <- cmd.scriptFlush
           _ <- putStrLn("Flushed all cached scripts!")

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisClusterSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisClusterSpec.scala
@@ -38,6 +38,8 @@ class RedisClusterSpec extends Redis4CatsFunSuite(true) with TestScenarios {
 
   test("cluster: server api")(withRedisCluster(serverScenario))
 
+  test("cluster: scripts")(withRedis(scriptsScenario))
+
   // FIXME: The Cluster impl cannot connect to a single node just yet
 //  test("cluster: transactions")(withRedisCluster(transactionScenario))
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
@@ -39,6 +39,8 @@ class RedisSpec extends Redis4CatsFunSuite(false) with TestScenarios {
   test("transactions")(withRedis(transactionScenario))
 
   test("server")(withRedis(serverScenario))
+
+  test("scripts")(withRedis(scriptsScenario))
 }
 
 object LongCodec extends JRedisCodec[String, Long] with ToByteBufEncoder[String, Long] {

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -273,15 +273,17 @@ trait TestScenarios {
         |return redis.status_reply('OK')""".stripMargin
     for {
       fortyTwo <- cmd.eval("return 42", ScriptOutputType.Integer)
-      _ <- IO { assert(fortyTwo == 42L) }
+      _ <- IO { assert(fortyTwo === 42L) }
       value <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
-      _ <- IO { assert(value == "Hello World") }
+      _ <- IO { assert(value === "Hello World") }
+      bool <- cmd.eval("return true", ScriptOutputType.Boolean)
+      _ <- IO { assert(bool) }
       list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi, Nil, "have", "fun")
-      _ <- IO { assert(list == List("Let", "us", "have", "fun")) }
+      _ <- IO { assert(list === List("Let", "us", "have", "fun")) }
       () <- cmd.eval(statusScript, ScriptOutputType.Status, List("test"), "foo")
       sha42 <- cmd.scriptLoad("return 42")
       fortyTwoSha <- cmd.evalSha(sha42, ScriptOutputType.Integer)
-      _ <- IO { assert(fortyTwoSha == 42L) }
+      _ <- IO { assert(fortyTwoSha === 42L) }
       shaStatusScript <- cmd.scriptLoad(statusScript)
       () <- cmd.evalSha(shaStatusScript, ScriptOutputType.Status, List("test"), "foo")
       exists <- cmd.scriptExists(sha42, "foobar")

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -278,14 +278,14 @@ trait TestScenarios {
       _ <- IO { assert(value === "Hello World") }
       bool <- cmd.eval("return true", ScriptOutputType.Boolean)
       _ <- IO { assert(bool) }
-      list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi[String], Nil, "have", "fun")
+      list <- cmd.evalWithValues("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi, Nil, "have", "fun")
       _ <- IO { assert(list === List("Let", "us", "have", "fun")) }
-      () <- cmd.eval(statusScript, ScriptOutputType.Status, List("test"), "foo")
+      () <- cmd.evalWithValues(statusScript, ScriptOutputType.Status, List("test"), "foo")
       sha42 <- cmd.scriptLoad("return 42")
       fortyTwoSha <- cmd.evalSha(sha42, ScriptOutputType.Integer)
       _ <- IO { assert(fortyTwoSha === 42L) }
       shaStatusScript <- cmd.scriptLoad(statusScript)
-      () <- cmd.evalSha(shaStatusScript, ScriptOutputType.Status, List("test"), "foo")
+      () <- cmd.evalShaWithValues(shaStatusScript, ScriptOutputType.Status, List("test"), "foo")
       exists <- cmd.scriptExists(sha42, "foobar")
       _ <- IO { assert(exists == List(true, false)) }
       () <- cmd.scriptFlush

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -265,4 +265,31 @@ trait TestScenarios {
 
   }
 
+  def scriptsScenario(cmd: RedisCommands[IO, String, String]): IO[Unit] = {
+    val statusScript =
+      """
+        |redis.call('set',KEYS[1],ARGV[1])
+        |redis.call('del',KEYS[1])
+        |return redis.status_reply('OK')""".stripMargin
+    for {
+      fortyTwo <- cmd.eval("return 42", ScriptOutputType.Integer)
+      _ <- IO { assert(fortyTwo == 42L) }
+      value <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
+      _ <- IO { assert(value == "Hello World") }
+      list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi, Nil, "have", "fun")
+      _ <- IO { assert(list == List("Let", "us", "have", "fun")) }
+      () <- cmd.eval(statusScript, ScriptOutputType.Status, List("test"), "foo")
+      sha42 <- cmd.scriptLoad("return 42")
+      fortyTwoSha <- cmd.evalSha(sha42, ScriptOutputType.Integer)
+      _ <- IO { assert(fortyTwoSha == 42L) }
+      shaStatusScript <- cmd.scriptLoad(statusScript)
+      () <- cmd.evalSha(shaStatusScript, ScriptOutputType.Status, List("test"), "foo")
+      exists <- cmd.scriptExists(sha42, "foobar")
+      _ <- IO { assert(exists == List(true, false)) }
+      () <- cmd.scriptFlush
+      exists2 <- cmd.scriptExists(sha42)
+      _ <- IO { assert(exists2 == List(false)) }
+    } yield ()
+  }
+
 }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -278,7 +278,7 @@ trait TestScenarios {
       _ <- IO { assert(value === "Hello World") }
       bool <- cmd.eval("return true", ScriptOutputType.Boolean)
       _ <- IO { assert(bool) }
-      list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi, Nil, "have", "fun")
+      list <- cmd.eval("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi[String], Nil, "have", "fun")
       _ <- IO { assert(list === List("Let", "us", "have", "fun")) }
       () <- cmd.eval(statusScript, ScriptOutputType.Status, List("test"), "foo")
       sha42 <- cmd.scriptLoad("return 42")

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -276,9 +276,9 @@ trait TestScenarios {
       _ <- IO { assert(fortyTwo === 42L) }
       value: String <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
       _ <- IO { assert(value === "Hello World") }
-      bool: Boolean <- cmd.evalWithKeys("return true", ScriptOutputType.Boolean, List("Foo"))
+      bool: Boolean <- cmd.eval("return true", ScriptOutputType.Boolean, List("Foo"))
       _ <- IO { assert(bool) }
-      list: List[String] <- cmd.evalWithKeysAndValues(
+      list: List[String] <- cmd.eval(
                              "return {'Let', 'us', ARGV[1], ARGV[2]}",
                              ScriptOutputType.Multi,
                              Nil,
@@ -288,12 +288,12 @@ trait TestScenarios {
                              )
                            )
       _ <- IO { assert(list === List("Let", "us", "have", "fun")) }
-      () <- cmd.evalWithKeysAndValues(statusScript, ScriptOutputType.Status, List("test"), List("foo"))
+      () <- cmd.eval(statusScript, ScriptOutputType.Status, List("test"), List("foo"))
       sha42 <- cmd.scriptLoad("return 42")
       fortyTwoSha: Long <- cmd.evalSha(sha42, ScriptOutputType.Integer)
       _ <- IO { assert(fortyTwoSha === 42L) }
       shaStatusScript <- cmd.scriptLoad(statusScript)
-      () <- cmd.evalShaWithKeysAndValues(shaStatusScript, ScriptOutputType.Status, List("test"), List("foo", "bar"))
+      () <- cmd.evalSha(shaStatusScript, ScriptOutputType.Status, List("test"), List("foo", "bar"))
       exists <- cmd.scriptExists(sha42, "foobar")
       _ <- IO { assert(exists === List(true, false)) }
       () <- cmd.scriptFlush

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -272,20 +272,20 @@ trait TestScenarios {
         |redis.call('del',KEYS[1])
         |return redis.status_reply('OK')""".stripMargin
     for {
-      fortyTwo <- cmd.eval("return 42", ScriptOutputType.Integer)
+      fortyTwo <- cmd.eval[Long]("return 42")
       _ <- IO { assert(fortyTwo === 42L) }
-      value <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
+      value <- cmd.eval[String]("return 'Hello World'")
       _ <- IO { assert(value === "Hello World") }
-      bool <- cmd.eval("return true", ScriptOutputType.Boolean)
+      bool <- cmd.eval[Boolean]("return true")
       _ <- IO { assert(bool) }
-      list <- cmd.evalWithValues("return {'Let', 'us', ARGV[1], ARGV[2]}", ScriptOutputType.Multi, Nil, "have", "fun")
+      list <- cmd.evalWithValues[List[String]]("return {'Let', 'us', ARGV[1], ARGV[2]}", Nil, "have", "fun")
       _ <- IO { assert(list === List("Let", "us", "have", "fun")) }
-      () <- cmd.evalWithValues(statusScript, ScriptOutputType.Status, List("test"), "foo")
+      () <- cmd.evalWithValues[Unit](statusScript, List("test"), "foo")
       sha42 <- cmd.scriptLoad("return 42")
-      fortyTwoSha <- cmd.evalSha(sha42, ScriptOutputType.Integer)
+      fortyTwoSha <- cmd.evalSha[Long](sha42)
       _ <- IO { assert(fortyTwoSha === 42L) }
       shaStatusScript <- cmd.scriptLoad(statusScript)
-      () <- cmd.evalShaWithValues(shaStatusScript, ScriptOutputType.Status, List("test"), "foo")
+      () <- cmd.evalShaWithValues[Unit](shaStatusScript, List("test"), "foo")
       exists <- cmd.scriptExists(sha42, "foobar")
       _ <- IO { assert(exists == List(true, false)) }
       () <- cmd.scriptFlush

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -278,11 +278,11 @@ trait TestScenarios {
       _ <- IO { assert(value === "Hello World") }
       bool: Boolean <- cmd.evalWithKeys("return true", ScriptOutputType.Boolean, List("Foo"))
       _ <- IO { assert(bool) }
-      list: List[String] <- cmd.evalWithKeys(
+      list: List[String] <- cmd.evalWithKeysAndValues(
                              "return {'Let', 'us', ARGV[1], ARGV[2]}",
                              ScriptOutputType.Multi,
+                             Nil,
                              List(
-                               "test",
                                "have",
                                "fun"
                              )

--- a/site/docs/effects/index.md
+++ b/site/docs/effects/index.md
@@ -13,6 +13,7 @@ The API that operates at the effect level `F[_]` on top of `cats-effect`.
 - **[Geo API](./geo.html)**
 - **[Hashes API](./hashes.html)**
 - **[Lists API](./lists.html)**
+- **[Scripting API](./scripting.html)**
 - **[Server API](./server.html)**
 - **[Sets API](./sets.html)**
 - **[Sorted SetsAPI](./sortedsets.html)**

--- a/site/docs/effects/scripting.md
+++ b/site/docs/effects/scripting.md
@@ -45,4 +45,4 @@ commandsApi.use { cmd => // ScriptCommands[IO, String, String]
 }
 ```
 
-The return type depends on the `ScriptOutputType` you pass and needs to suite the result of the Lua script itself. Possible values are `Integer`, `Value` (for decoding the result using the value codec), `Multi` (for many values) and `Status` (maps to `Unit` in Scala). On Scala 2.12, it might be necessary to pass the type of the value to the `ScriptOutputType`, e.g. `ScriptOutputType.Multi[String]` – otherwise the compiler might not be able to type check. Scripts can be cached for better performance using `scriptLoad` and then executed via `evalSha`, see the [redis docs]((https://redis.io/commands#scripting)) for details.
+The return type depends on the `ScriptOutputType` you pass and needs to suite the result of the Lua script itself. Possible values are `Integer`, `Value` (for decoding the result using the value codec), `Multi` (for many values) and `Status` (maps to `Unit` in Scala). Scripts can be cached for better performance using `scriptLoad` and then executed via `evalSha`, see the [redis docs]((https://redis.io/commands#scripting)) for details.

--- a/site/docs/effects/scripting.md
+++ b/site/docs/effects/scripting.md
@@ -36,9 +36,10 @@ import cats.effect.IO
 
 def putStrLn(str: String): IO[Unit] = IO(println(str))
 
-commandsApi.use { cmd => // ScriptCommands[IO]
+commandsApi.use { cmd => // ScriptCommands[IO, String, String]
   for {
-    greeting <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
+    // returns a String according the value codec (the last type parameter of ScriptCommands)
+    greeting: String <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
     _ <- putStrLn(s"Greetings from Lua: $greeting")
   } yield ()
 }

--- a/site/docs/effects/scripting.md
+++ b/site/docs/effects/scripting.md
@@ -1,0 +1,47 @@
+---
+layout: docs
+title:  "Scripting"
+number: 12
+---
+
+# Scripting API
+
+Purely functional interface for the [Scripting API](https://redis.io/commands#scripting).
+
+```scala mdoc:invisible
+import cats.effect.{IO, Resource}
+import cats.implicits._
+import dev.profunktor.redis4cats.algebra.ScriptCommands
+import dev.profunktor.redis4cats.effects.ScriptOutputType
+import dev.profunktor.redis4cats.interpreter.Redis
+import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+
+val commandsApi: Resource[IO, ScriptCommands[IO, String, String]] = {
+  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ScriptCommands[IO, String, String]]
+}
+```
+
+### Script Commands usage
+
+Once you have acquired a connection you can start using it:
+
+```scala mdoc:silent
+import cats.effect.IO
+
+def putStrLn(str: String): IO[Unit] = IO(println(str))
+
+commandsApi.use { cmd => // ScriptCommands[IO]
+  for {
+    greeting <- cmd.eval("return 'Hello World'", ScriptOutputType.Value)
+    _ <- putStrLn(s"Greetings from Lua: $greeting")
+  } yield ()
+}
+```
+
+The return type depends on the `ScriptOutputType` you pass and needs to suite the result of the Lua script itself. Possible values are `Integer`, `Value` (for decoding the result using the value codec), `Multi` (for many values) and `Status` (maps to `Unit` in Scala). Scripts can be cached for better performance using `scriptLoad` and then executed via `evalSha`, see the [redis docs]((https://redis.io/commands#scripting)) for details.

--- a/site/docs/effects/scripting.md
+++ b/site/docs/effects/scripting.md
@@ -45,4 +45,4 @@ commandsApi.use { cmd => // ScriptCommands[IO, String, String]
 }
 ```
 
-The return type depends on the `ScriptOutputType` you pass and needs to suite the result of the Lua script itself. Possible values are `Integer`, `Value` (for decoding the result using the value codec), `Multi` (for many values) and `Status` (maps to `Unit` in Scala). Scripts can be cached for better performance using `scriptLoad` and then executed via `evalSha`, see the [redis docs]((https://redis.io/commands#scripting)) for details.
+The return type depends on the `ScriptOutputType` you pass and needs to suite the result of the Lua script itself. Possible values are `Integer`, `Value` (for decoding the result using the value codec), `Multi` (for many values) and `Status` (maps to `Unit` in Scala). On Scala 2.12, it might be necessary to pass the type of the value to the `ScriptOutputType`, e.g. `ScriptOutputType.Multi[String]` – otherwise the compiler might not be able to type check. Scripts can be cached for better performance using `scriptLoad` and then executed via `evalSha`, see the [redis docs]((https://redis.io/commands#scripting)) for details.

--- a/site/src/main/resources/microsite/data/menu.yml
+++ b/site/src/main/resources/microsite/data/menu.yml
@@ -24,6 +24,10 @@ options:
         url: effects/lists.html
         menu_section: effectapi
 
+      - title: Scripting
+        url: effects/scripting.html
+        menu_section: effectapi
+
       - title: Server
         url: effects/server.html
         menu_section: effectapi


### PR DESCRIPTION
Includes a separate Algebra for scripting-related commands and their implementation and BaseRedis. Plus tests, demo and docs.

Use case: A lot of interesting applications with Redis rely on some atomicity you can't get by just sending simple commands over wire, so you have to rely on Lua scripting, for example for locking algorithms: https://redis.io/topics/distlock

Most of the implementation is straight-forward wrapping of Lettuce, I'll comment below on one or two unusual things. Feedback and ideas for improvements on these especially welcome!