### PR TITLE
Fixing hanging transactions

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -640,7 +640,8 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
 
   override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit): F[Set[V]] =
     JRFuture {
-      async.flatMap(c => F.delay(c.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit))
+      async.flatMap(c =>
+        F.delay(c.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit))
       )
     }.map(_.asScala.toSet)
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/LoggerIOApp.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/LoggerIOApp.scala
@@ -35,9 +35,7 @@ trait LoggerIOApp extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     Slf4jLogger
       .create[IO]
-      .flatMap { implicit logger: Logger[IO] =>
-        program
-      }
+      .flatMap { implicit logger: Logger[IO] => program }
       .as(ExitCode.Success)
 
 }

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
@@ -52,8 +52,8 @@ object PubSubDemo extends LoggerIOApp {
              Stream.awakeEvery[IO](5.seconds) >> Stream.emit("Pac-Man!").through(pub2),
              Stream.awakeDelay[IO](11.seconds) >> pubSub.unsubscribe(gamesChannel),
              Stream.awakeEvery[IO](6.seconds) >> pubSub
-               .pubSubSubscriptions(List(eventsChannel, gamesChannel))
-               .evalMap(putStrLn)
+                   .pubSubSubscriptions(List(eventsChannel, gamesChannel))
+                   .evalMap(putStrLn)
            ).parJoin(6).drain
     } yield rs
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
@@ -41,8 +41,8 @@ object PublisherDemo extends LoggerIOApp {
       rs <- Stream(
              Stream.awakeEvery[IO](3.seconds) >> Stream.eval(IO(Random.nextInt(100).toString)).through(pub1),
              Stream.awakeEvery[IO](6.seconds) >> pubSub
-               .pubSubSubscriptions(eventsChannel)
-               .evalMap(putStrLn)
+                   .pubSubSubscriptions(eventsChannel)
+                   .evalMap(putStrLn)
            ).parJoin(2).drain
     } yield rs
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
@@ -48,7 +48,7 @@ object RedisTransactionsDemo extends LoggerIOApp {
 
         val getters =
           cmd.get(key1).flatTap(showResult(key1)) *>
-            cmd.get(key2).flatTap(showResult(key2))
+              cmd.get(key2).flatTap(showResult(key2))
 
         val tx1 = tx.run(
           cmd.set(key1, "foo"),

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/interpreter/pubsub/LivePubSubCommands.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/interpreter/pubsub/LivePubSubCommands.scala
@@ -47,7 +47,7 @@ class LivePubSubCommands[F[_]: ConcurrentEffect: ContextShift: Log, K, V](
     _.evalMap { message =>
       state.get.flatMap { st =>
         PubSubInternals[F, K, V](state, subConnection).apply(channel)(st) *>
-          JRFuture { F.delay(pubConnection.async().publish(channel.underlying, message)) }
+          JRFuture(F.delay(pubConnection.async().publish(channel.underlying, message)))
       }.void
     }
 

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/interpreter/pubsub/Publisher.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/interpreter/pubsub/Publisher.scala
@@ -31,9 +31,7 @@ class Publisher[F[_]: ConcurrentEffect: ContextShift, K, V](pubConnection: State
   private[redis4cats] val pubSubStats: PubSubStats[Stream[F, *], K] = new LivePubSubStats(pubConnection)
 
   override def publish(channel: RedisChannel[K]): Stream[F, V] => Stream[F, Unit] =
-    _.evalMap { message =>
-      JRFuture { F.delay(pubConnection.async().publish(channel.underlying, message)) }.void
-    }
+    _.evalMap(message => JRFuture(F.delay(pubConnection.async().publish(channel.underlying, message))).void)
 
   override def pubSubChannels: Stream[F, List[K]] =
     pubSubStats.pubSubChannels

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -91,7 +91,7 @@ commandsApi.use { cmd =>
 
 You should never pass a transactional command: `MULTI`, `EXEC` or `DISCARD`.
 
-The following example will result in a successful transaction that raises an error (resulting in a failed computation):
+The following example will result in a successful transaction; the error will be swallowed:
 
 ```scala mdoc:silent
 commandsApi.use { cmd =>


### PR DESCRIPTION
Transactions were working but any computation running after a transaction was never executed due to the core of the transactions hanging while trying to join spawned fibers (which happen to be Lettuce commands that never return).

This fix removes the joins and always cancels all the spawned fibers, which in case of a completed computation it'll be a no-op.

Still, if you can avoid using transactions, prefer not to use this.

/cc @sloshy