### PR TITLE
Fix timeout unit for blPop, brPop & brPopLPush

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/interpreter/Redis.scala
@@ -549,17 +549,17 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
 
   override def blPop(timeout: FiniteDuration, keys: K*): F[(K, V)] =
     JRFuture {
-      async.flatMap(c => F.delay(c.blpop(timeout.toMillis, keys: _*)))
+      async.flatMap(c => F.delay(c.blpop(timeout.toSeconds, keys: _*)))
     }.map(kv => kv.getKey -> kv.getValue)
 
   override def brPop(timeout: FiniteDuration, keys: K*): F[(K, V)] =
     JRFuture {
-      async.flatMap(c => F.delay(c.brpop(timeout.toMillis, keys: _*)))
+      async.flatMap(c => F.delay(c.brpop(timeout.toSeconds, keys: _*)))
     }.map(kv => kv.getKey -> kv.getValue)
 
   override def brPopLPush(timeout: FiniteDuration, source: K, destination: K): F[Option[V]] =
     JRFuture {
-      async.flatMap(c => F.delay(c.brpoplpush(timeout.toMillis, source, destination)))
+      async.flatMap(c => F.delay(c.brpoplpush(timeout.toSeconds, source, destination)))
     }.map(Option.apply)
 
   override def lPop(key: K): F[Option[V]] =
@@ -640,7 +640,8 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
 
   override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit): F[Set[V]] =
     JRFuture {
-      async.flatMap(c => F.delay(c.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit))
+      async.flatMap(c =>
+        F.delay(c.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit))
       )
     }.map(_.asScala.toSet)
 


### PR DESCRIPTION
These commands take their timeout in seconds (see Lettuce Javadoc or https://redis.io/commands/blpop#blocking-behavior), but the `Redis` interpreter converted the given `FiniteDuration` into milliseconds.

PS: Given the fact that a `0` timeout means infinite blocking according to the Redis docs, I wonder whether it would make sense to take an `Option[FiniteDuration]` (`None` = no timeout = `0` sent to Redis) or just a `Duration` (and map `Duration.Inf` to `0`). Any opinions?