### PR TITLE
Add documentation section to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ guide](https://github.com/profunktor/redis4cats/wiki/Migration-guide-(Vim))).
 libraryDependencies += "dev.profunktor" %% "redis4cats-log4cats" % Version
 ```
 
+## Documentation
+Guides and examples can be found on the [micro site](https://redis4cats.profunktor.dev).
+
+The scala docs can be found here by module:
+* Core [![javadoc](https://javadoc.io/badge2/dev.profunktor/redis4cats-core_2.13/javadoc.svg)](https://javadoc.io/doc/dev.profunktor/redis4cats-core_2.13)
+* Effects [![javadoc](https://javadoc.io/badge2/dev.profunktor/redis4cats-effects_2.13/javadoc.svg)](https://javadoc.io/doc/dev.profunktor/redis4cats-effects_2.13)
+* Streams [![javadoc](https://javadoc.io/badge2/dev.profunktor/redis4cats-streams_2.13/javadoc.svg)](https://javadoc.io/doc/dev.profunktor/redis4cats-streams_2.13)
+* Log4cats [![javadoc](https://javadoc.io/badge2/dev.profunktor/redis4cats-log4cats_2.13/javadoc.svg)](https://javadoc.io/doc/dev.profunktor/redis4cats-log4cats_2.13)
+
 ## Running the tests locally
 
 Start both a single Redis node and a cluster using `docker-compose`:


### PR DESCRIPTION
Adds a link to the micro site and badges for all modules on javadoc.io (they automatically point to the latest version, no update needed).

Closes #251 