### PR TITLE
Re-working the transactions model for good

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ redis4cats
 
 Redis client built on top of [Cats Effect](https://typelevel.org/cats-effect/), [Fs2](http://fs2.io/) and the async Java client [Lettuce](https://lettuce.io/).
 
-> **NOTE**: Neither binary compatibility nor API stability are guaranteed between releases.
+> **NOTE**: Neither binary compatibility nor API stability will be guaranteed until we reach `1.0.0`.
 
 `redis4cats` defines two types of API: an effect-based using [Cats Effect](https://typelevel.org/cats-effect/) and a stream-based using [Fs2](http://fs2.io/).
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
@@ -53,10 +53,13 @@ object RedisClusterTransactionsDemo extends LoggerIOApp {
             } yield nodeCmd
 
           // Transactions are only supported on a single node
-          val notAllowed =
-            cmd.multi.bracket(_ => cmd.set(key1, "nope") *> cmd.exec)(_ => cmd.discard).handleErrorWith {
-              case e: OperationNotSupported => putStrLn(e)
-            }
+          val notAllowed: IO[Unit] =
+            cmd.multi
+              .bracket(_ => cmd.set(key1, "nope") >> cmd.exec.void)(_ => cmd.discard)
+              .handleErrorWith {
+                case e: OperationNotSupported => putStrLn(e)
+              }
+              .void
 
           notAllowed *>
             // Transaction runs in a single shard, where "key1" is stored

--- a/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
+++ b/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 ProfunKtor
+ * Copyright 2018-2020 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -17,7 +17,7 @@ Redis supports [transactions](https://redis.io/topics/transactions) via the `MUL
 
 The most common way is to create a `RedisTransaction` once by passing the commands API as a parameter and invoke the `run` function every time you want to run the given commands as part of a new transaction.
 
-Note that every command has to be forked (`.start`) because the commands need to be sent to the server asynchronously and no response will be received until either an `EXEC` or a `DISCARD` command is sent. Both forking and sending the final command is handled by `RedisTransaction`. Also, it is not possible to sequence commands (`flatMap`) that are part of a transaction. Every command has to be atomic and independent of previous results.
+Note that every command has to be forked (`.start`) because the commands need to be sent to the server asynchronously and no response will be received until either an `EXEC` or a `DISCARD` command is sent. Both forking and sending the final command is handled by `RedisTransaction`. Every command has to be atomic and independent of previous results, so it wouldn't make sense to chain commands using `flatMap` (though, it would technically work).
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
@@ -29,7 +29,7 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, RedisCommands[IO, String, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]])

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -27,8 +27,10 @@ import dev.profunktor.redis4cats.domain._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import scala.concurrent.ExecutionContext
 
-implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val timer = IO.timer(ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, RedisCommands[IO, String, String]] = {


### PR DESCRIPTION
I've been working hard on getting this right. So far, this is the most corrected model that seems to work consistently.

- `MULTI`, `EXEC`, `DISCARD`, `WATCH`, and `UNWATCH` commands now run using the Sync API.
- `tx.run(...)` now returns `F[List[Any]]`, a collection of the raw results of the transaction.

Here's an example taken from `RedisTransactionsDemo.scala`:

```scala
commandsApi
  .use { cmd =>
    val tx = RedisTransaction(cmd)

    val getters =
      cmd.get(key1).flatTap(showResult(key1)) *>
          cmd.get(key2).flatTap(showResult(key2))

    val tx1 =
      tx.run(
          cmd.set(key1, "sad"),
          cmd.set(key2, "windows"),
          cmd.get(key1),
          cmd.set(key1, "nix"),
          cmd.set(key2, "linux"),
          cmd.get(key1)
        )
        .handleErrorWith {
          case TransactionAborted =>
            putStrLn("[Error] - Transaction Aborted").as(List.empty)
          case _: TimeoutException =>
            putStrLn("[Error] - Timeout").as(List.empty)
        }

    getters >> tx1.flatMap {
      case (() :: () :: Some("sad") :: () :: () :: Some("nix") :: Nil) =>
        putStrLn(">>> Got expected result")
      case xs =>
        putStrLn(">>> Unexpected result") >> xs.traverse_(putStrLn)
    } >> getters.void >> putStrLn("Some more computations after tx...")
  }
}
```

---------

### What's left to do

There's still some more work ahead:

- Documentation of transactions, including usage of `WATCH` and `UNWATCH`.
- More integration tests for the new transaction model.
- Probably think about returning an `HList` as the result of the transaction, so it can be typed according to the commands we pass in. This will require more thinking and it's probably just a nice-to-have.
- Another idea is to stick to `List[Any]` but to filter out `()` values (`Unit`), which are irrelevant.

### Upcoming release

Once this gets merged I will make a release. I'm not sure whether it breaks binary compatibility or not since we haven't set up MiMa yet, so my question is:

Would you prefer `0.9.7` or a `0.10.0` release? I'm okay with either since I normally use this library only in applications and don't care about binary compatibility with previous versions. 