### PR TITLE
Free Applicative Transaction Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ tq:q
 .sbtopts
 .metals
 .bloop
+project/metals.sbt

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/redis.scala
@@ -16,6 +16,8 @@
 
 package dev.profunktor.redis4cats.algebra
 
+import cats.effect.{ Concurrent, ContextShift }
+
 trait RedisCommands[F[_], K, V]
     extends StringCommands[F, K, V]
     with HashCommands[F, K, V]
@@ -28,4 +30,6 @@ trait RedisCommands[F[_], K, V]
     with TransactionalCommands[F, K]
     with PipelineCommands[F]
     with ScriptCommands[F, K, V]
-    with KeyCommands[F, K]
+    with KeyCommands[F, K] {
+  def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V]
+}

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/redis.scala
@@ -16,8 +16,6 @@
 
 package dev.profunktor.redis4cats.algebra
 
-import cats.effect.{ Concurrent, ContextShift }
-
 trait RedisCommands[F[_], K, V]
     extends StringCommands[F, K, V]
     with HashCommands[F, K, V]
@@ -30,6 +28,4 @@ trait RedisCommands[F[_], K, V]
     with TransactionalCommands[F, K]
     with PipelineCommands[F]
     with ScriptCommands[F, K, V]
-    with KeyCommands[F, K] {
-  def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V]
-}
+    with KeyCommands[F, K]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
@@ -69,12 +69,12 @@ object transactions {
     def builder[F[_], K, V]: Builder[F, K, V] = new Builder[F, K, V]
 
     /**
-     * The Builder is a Partially Applied Constructor Allowing operations to fully infer.
+      * The Builder is a Partially Applied Constructor Allowing operations to fully infer.
      **/
     class Builder[F[_], K, V] {
-      def operation[A](r: RedisCommands[F, K, V] => F[A]): RedisTransactionB[F, K, V, A] = 
+      def operation[A](r: RedisCommands[F, K, V] => F[A]): RedisTransactionB[F, K, V, A] =
         RedisTransactionB.operation(r)
-      def pure[A](a: A): RedisTransactionB[F, K, V, A] = 
+      def pure[A](a: A): RedisTransactionB[F, K, V, A] =
         RedisTransactionB.pure(a)
     }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
@@ -17,7 +17,7 @@
 package dev.profunktor.redis4cats
 
 import cats.effect._
-import cats.effect.concurrent.Ref
+import cats.effect.concurrent._
 import cats.effect.implicits._
 import cats.implicits._
 import dev.profunktor.redis4cats.algebra._
@@ -58,6 +58,96 @@ object transactions {
           tx.use(_ => commands.toList.traverse(_.start).flatMap(fibers.set))
             .guarantee(cancelFibers)
       }
+  }
+
+  sealed trait RedisTransactionB[F[_], K, V, A] {
+    def transact(commands: RedisCommands[F, K, V])(implicit F: Concurrent[F], L: Log[F]): F[A]
+
+  }
+  object RedisTransactionB {
+
+    def operation[F[_], K, V, A](r: RedisCommands[F, K, V] => F[A]): RedisTransactionB[F, K, V, A] =
+      Operation(r)
+
+    def pure[F[_], K, V, A](a: A): RedisTransactionB[F, K, V, A] =
+      Pure(a)
+
+    def ap[F[_], K, V, A, B](
+        ff: RedisTransactionB[F, K, V, A => B],
+        fa: RedisTransactionB[F, K, V, A]
+    ): RedisTransactionB[F, K, V, B] =
+      Ap(
+        ff.asInstanceOf[RedisTransactionInternal[F, K, V, A => B]], // Safe ONLY because we are PRIVATE
+        fa.asInstanceOf[RedisTransactionInternal[F, K, V, A]]
+      )
+
+    private sealed trait RedisTransactionInternal[F[_], K, V, A] extends RedisTransactionB[F, K, V, A] {
+      final def transact(cmd: RedisCommands[F, K, V])(implicit F: Concurrent[F], L: Log[F]): F[A] =
+        (Resource.makeCase(cmd.multi) {
+          case (_, ExitCase.Completed) => F.unit
+          case (_, ExitCase.Error(e)) =>
+            cmd.discard *> L.error(s"Transaction failed: ${e.getMessage}")
+          case (_, ExitCase.Canceled) =>
+            cmd.discard *> L.error("Transaction canceled")
+        } >> Resource.liftF(L.info("Transaction started")) >> runInternal(cmd)).use { fib =>
+          cmd.exec *>
+            L.info("Transaction completed") *>
+            fib.join
+        }
+
+      def runInternal(commands: RedisCommands[F, K, V])(implicit F: Concurrent[F], L: Log[F]): Resource[F, Fiber[F, A]]
+    }
+
+    def forkBackground[F[_]: Concurrent, A](fa: F[A]): Resource[F, Fiber[F, A]] =
+      Resource.make(fa.start)(_.cancel)
+
+    private final case class Pure[F[_], K, V, A](a: A) extends RedisTransactionInternal[F, K, V, A] {
+      override def runInternal(
+          commands: RedisCommands[F, K, V]
+      )(implicit F: Concurrent[F], L: Log[F]): Resource[F, Fiber[F, A]] =
+        Resource.pure[F, Fiber[F, A]](a.pure[Fiber[F, *]])
+    }
+    private final case class Operation[F[_], K, V, A](withCommands: RedisCommands[F, K, V] => F[A])
+        extends RedisTransactionInternal[F, K, V, A] {
+      override def runInternal(
+          commands: RedisCommands[F, K, V]
+      )(implicit F: Concurrent[F], L: Log[F]): Resource[F, Fiber[F, A]] =
+        forkBackground(withCommands(commands))
+    }
+
+    private final case class Ap[F[_], K, V, A, B](
+        f: RedisTransactionInternal[F, K, V, A => B],
+        a: RedisTransactionInternal[F, K, V, A]
+    ) extends RedisTransactionInternal[F, K, V, B] {
+
+      override def runInternal(
+          cmd: RedisCommands[F, K, V]
+      )(implicit F: Concurrent[F], L: Log[F]): Resource[F, Fiber[F, B]] =
+        for {
+          ff: Fiber[F, A => B] <- f.runInternal(cmd)
+          fa: Fiber[F, A] <- a.runInternal(cmd)
+        } yield ff.ap(fa)
+    }
+
+    implicit def applicative[F[_], K, V]: cats.Applicative[RedisTransactionB[F, K, V, *]] =
+      new cats.Applicative[RedisTransactionB[F, K, V, *]] {
+        def ap[A, B](ff: RedisTransactionB[F, K, V, A => B])(
+            fa: RedisTransactionB[F, K, V, A]
+        ): RedisTransactionB[F, K, V, B]                 = RedisTransactionB.ap(ff, fa)
+        def pure[A](x: A): RedisTransactionB[F, K, V, A] = RedisTransactionB.pure[F, K, V, A](x)
+      }
+  }
+
+  object Example {
+    final case class Model(a: Option[String], b: Option[String])
+    def getModel[F[_]] =
+      (
+        RedisTransactionB.operation[F, String, String, Option[String]](_.get("foo")),
+        RedisTransactionB.operation[F, String, String, Option[String]](_.get("bar"))
+      ).mapN(Model.apply)
+
+    def transaction[F[_]: Concurrent: Log](commands: RedisCommands[F, String, String]): F[Model] =
+      getModel[F].transact(commands)
   }
 
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
@@ -150,16 +150,4 @@ object transactions {
       }
   }
 
-  object Example {
-    final case class Model(a: Option[String], b: Option[String])
-    def getModel[F[_]] =
-      (
-        RedisTransactionB.operation[F, String, String, Option[String]](_.get("foo")),
-        RedisTransactionB.operation[F, String, String, Option[String]](_.get("bar"))
-      ).mapN(Model.apply)
-
-    def transaction[F[_]: Concurrent: Log](commands: RedisCommands[F, String, String]): F[Model] =
-      getModel[F].transact(commands)
-  }
-
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
@@ -66,6 +66,18 @@ object transactions {
   }
   object RedisTransactionB {
 
+    def builder[F[_], K, V]: Builder[F, K, V] = new Builder[F, K, V]
+
+    /**
+     * The Builder is a Partially Applied Constructor Allowing operations to fully infer.
+     **/
+    class Builder[F[_], K, V] {
+      def operation[A](r: RedisCommands[F, K, V] => F[A]): RedisTransactionB[F, K, V, A] = 
+        RedisTransactionB.operation(r)
+      def pure[A](a: A): RedisTransactionB[F, K, V, A] = 
+        RedisTransactionB.pure(a)
+    }
+
     def operation[F[_], K, V, A](r: RedisCommands[F, K, V] => F[A]): RedisTransactionB[F, K, V, A] =
       Operation(r)
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
@@ -55,9 +55,10 @@ object RedisTransactionsDemo extends LoggerIOApp {
           cmd.set(key2, "bar")
         )
 
+        val tBuilder = RedisTransactionB.builder[IO, String, String]
         val txop2 = (
-          RedisTransactionB.operation[IO, String, String, Unit](_.set(key1, "foo1")),
-          RedisTransactionB.operation[IO, String, String, Unit](_.set(key2, "bar2"))
+          tBuilder.operation(_.set(key1, "foo1")),
+          tBuilder.operation(_.set(key2, "bar2"))
         ).tupled.void
 
         val tx2 = txop2.transact(cmd)

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
@@ -55,7 +55,16 @@ object RedisTransactionsDemo extends LoggerIOApp {
           cmd.set(key2, "bar")
         )
 
-        getters *> tx1 *> getters.void
+        val txop2 = (
+          RedisTransactionB.operation[IO, String, String, Unit](_.set(key1, "foo1")),
+          RedisTransactionB.operation[IO, String, String, Unit](_.set(key2, "bar2"))
+        ).tupled.void
+
+        val tx2 = txop2.transact(cmd)
+
+        getters *> tx1 *> getters *>
+          tx2 *> getters.void
+
       }
   }
 

--- a/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
+++ b/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 ProfunKtor
+ * Copyright 2018-2020 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.8


### PR DESCRIPTION
- Removes liftK which allows for a mapK implementation for commands, exposes liftK only on the root client impl, after a transformation the ability is lost.

- Creates a Free Applicative model for transactions allowing you to compose them. Operations should be seen as a linear resource and used for a single operation.(Failure to do so will result in the second computation happening outside the transaction). Keeps all type information.


- TODO: Remove Example
- TODO: Better Name if this is liked 

```
[info] running dev.profunktor.redis4cats.RedisTransactionsDemo
14:43:09.354 [ioapp-compute-0] INFO  io.lettuce.core.EpollProvider - Starting without optional epoll library
14:43:09.358 [ioapp-compute-0] INFO  io.lettuce.core.KqueueProvider - Starting without optional kqueue library
foo1
bar2
14:43:09.696 [ioapp-compute-3] INFO  d.profunktor.redis4cats.LoggerIOApp - Transaction started
14:43:09.712 [ioapp-compute-1] INFO  d.profunktor.redis4cats.LoggerIOApp - Transaction completed
foo
bar
14:43:09.719 [ioapp-compute-5] INFO  d.profunktor.redis4cats.LoggerIOApp - Transaction started
14:43:09.731 [ioapp-compute-1] INFO  d.profunktor.redis4cats.LoggerIOApp - Transaction completed
foo1
bar2
14:43:09.739 [ioapp-compute-7] INFO  d.profunktor.redis4cats.LoggerIOApp - Releasing Commands connection: RedisURI [host='localhost', port=6379]
14:43:09.742 [ioapp-compute-7] INFO  d.profunktor.redis4cats.LoggerIOApp - Releasing Redis connection: RedisURI(RedisURI [host='localhost', port=6379])
```

As you can see behavior looks the same between the old void approach and the 
free-applicative model. Except the applicative model retains type information. This also means you can include reads easily in the transactions if you want as well.