### PR TITLE
Simpler package naming

### DIFF
--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/Codecs.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/Codecs.scala
@@ -16,12 +16,11 @@
 
 package dev.profunktor.redis4cats.codecs
 
-import dev.profunktor.redis4cats.domain.RedisCodec
-import java.nio.ByteBuffer
-
 import dev.profunktor.redis4cats.codecs.splits.SplitEpi
+import dev.profunktor.redis4cats.data.RedisCodec
 import io.lettuce.core.codec.{ RedisCodec => JRedisCodec, ToByteBufEncoder }
 import io.netty.buffer.ByteBuf
+import java.nio.ByteBuffer
 
 object Codecs {
 

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClient.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClient.scala
@@ -17,8 +17,7 @@
 package dev.profunktor.redis4cats.connection
 
 import cats.effect._
-import cats.syntax.apply._
-import cats.syntax.functor._
+import cats.implicits._
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log }
 import dev.profunktor.redis4cats.effect.JRFuture._
 import io.lettuce.core.{ RedisClient => JRedisClient, RedisURI => JRedisURI }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClusterClient.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClusterClient.scala
@@ -19,7 +19,7 @@ package dev.profunktor.redis4cats.connection
 import cats.effect._
 import cats.implicits._
 import dev.profunktor.redis4cats.JavaConversions._
-import dev.profunktor.redis4cats.domain.NodeId
+import dev.profunktor.redis4cats.data.NodeId
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log }
 import dev.profunktor.redis4cats.effect.JRFuture._
 import io.lettuce.core.cluster.{ SlotHash, RedisClusterClient => JClusterClient }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisConnection.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisConnection.scala
@@ -18,7 +18,7 @@ package dev.profunktor.redis4cats.connection
 
 import cats.effect._
 import cats.syntax.all._
-import dev.profunktor.redis4cats.domain.NodeId
+import dev.profunktor.redis4cats.data.NodeId
 import dev.profunktor.redis4cats.effect.JRFuture
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisMasterReplica.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisMasterReplica.scala
@@ -19,7 +19,7 @@ package dev.profunktor.redis4cats.connection
 import cats.effect._
 import cats.syntax.all._
 import dev.profunktor.redis4cats.JavaConversions._
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log }
 import dev.profunktor.redis4cats.effect.JRFuture._
 import io.lettuce.core.masterreplica.{ MasterReplica, StatefulRedisMasterReplicaConnection }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/data.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/data.scala
@@ -21,7 +21,7 @@ import io.lettuce.core.codec.{ RedisCodec => JRedisCodec, StringCodec, ToByteBuf
 import io.lettuce.core.{ KeyScanCursor => JKeyScanCursor }
 import dev.profunktor.redis4cats.JavaConversions._
 
-object domain {
+object data {
 
   final case class RedisChannel[K](underlying: K) extends AnyVal
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
@@ -14,17 +14,23 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.algebra
+package dev.profunktor.redis4cats
 
-import dev.profunktor.redis4cats.streams._
+import algebra._
+import cats.effect.{ Concurrent, ContextShift }
 
-// format: off
-trait RawStreaming[F[_], K, V] {
-  def xAdd(key: K, body: Map[K, V]): F[MessageId]
-  def xRead(streams: Set[StreamingOffset[K]]): F[List[StreamingMessageWithId[K, V]]]
-}
-
-trait Streaming[F[_], K, V] {
-  def append: F[StreamingMessage[K, V]] => F[Unit]
-  def read(keys: Set[K], initialOffset: K => StreamingOffset[K] = StreamingOffset.All[K]): F[StreamingMessageWithId[K, V]]
+trait RedisCommands[F[_], K, V]
+    extends StringCommands[F, K, V]
+    with HashCommands[F, K, V]
+    with SetCommands[F, K, V]
+    with SortedSetCommands[F, K, V]
+    with ListCommands[F, K, V]
+    with GeoCommands[F, K, V]
+    with ConnectionCommands[F]
+    with ServerCommands[F, K]
+    with TransactionalCommands[F, K]
+    with PipelineCommands[F]
+    with ScriptCommands[F, K, V]
+    with KeyCommands[F, K] {
+  def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/pipeline.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/pipeline.scala
@@ -19,7 +19,6 @@ package dev.profunktor.redis4cats
 import cats.effect._
 import cats.effect.implicits._
 import cats.implicits._
-import dev.profunktor.redis4cats.algebra._
 import dev.profunktor.redis4cats.effect.Log
 
 object pipeline {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter
+package dev.profunktor.redis4cats
 
 import java.time.Instant
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.algebra._
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log, RedisBlocker }
 import dev.profunktor.redis4cats.effect.JRFuture._
 import dev.profunktor.redis4cats.effects._

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/transactions.scala
@@ -20,7 +20,6 @@ import cats.effect._
 import cats.effect.concurrent._
 import cats.effect.implicits._
 import cats.implicits._
-import dev.profunktor.redis4cats.algebra._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.hlist._
 import scala.concurrent.duration._

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/Demo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/Demo.scala
@@ -19,7 +19,7 @@ package dev.profunktor.redis4cats
 import cats.effect.IO
 import dev.profunktor.redis4cats.codecs.Codecs
 import dev.profunktor.redis4cats.codecs.splits._
-import dev.profunktor.redis4cats.domain.RedisCodec
+import dev.profunktor.redis4cats.data.RedisCodec
 
 object Demo {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
@@ -18,9 +18,9 @@ package dev.profunktor.redis4cats
 
 import cats.effect.IO
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.domain.RedisChannel
+import dev.profunktor.redis4cats.data.RedisChannel
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.pubsub.PubSub
+import dev.profunktor.redis4cats.pubsub.PubSub
 import fs2.{ Pipe, Stream }
 
 import scala.concurrent.duration._

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
@@ -18,9 +18,9 @@ package dev.profunktor.redis4cats
 
 import cats.effect.IO
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.domain.RedisChannel
+import dev.profunktor.redis4cats.data.RedisChannel
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.pubsub.PubSub
+import dev.profunktor.redis4cats.pubsub.PubSub
 import fs2.Stream
 
 import scala.concurrent.duration._

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
@@ -17,10 +17,10 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.StringCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisClusterStringsDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.StringCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
@@ -18,11 +18,9 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import cats.implicits._
-import dev.profunktor.redis4cats.algebra.RedisCommands
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.connection.RedisClusterClient
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 import dev.profunktor.redis4cats.transactions._
 
 object RedisClusterTransactionsDemo extends LoggerIOApp {

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import cats.implicits._
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.transactions._

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.GeoCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
@@ -17,11 +17,11 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.GeoCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.effects._
-import dev.profunktor.redis4cats.interpreter.Redis
 import io.lettuce.core.GeoArgs
 
 object RedisGeoDemo extends LoggerIOApp {

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
@@ -17,10 +17,10 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.HashCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisHashesDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.HashCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.{ KeyCommands, StringCommands }
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
@@ -17,10 +17,10 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.{ KeyCommands, StringCommands }
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisKeysDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ListCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
@@ -17,10 +17,10 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ListCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisListsDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
@@ -17,11 +17,10 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.algebra.RedisCommands
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.domain.ReadFrom
+import dev.profunktor.redis4cats.data.ReadFrom
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisMasterReplicaStringsDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data.ReadFrom
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.pipeline._

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
@@ -18,10 +18,9 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.algebra.RedisCommands
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 import dev.profunktor.redis4cats.pipeline._
 import scala.concurrent.duration._
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -17,11 +17,11 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ScriptCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.effects.ScriptOutputType
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisScriptsDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ScriptCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
@@ -17,10 +17,10 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.SetCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisSetsDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.SetCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.SortedSetCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
@@ -17,11 +17,11 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.SortedSetCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.effects.{ Score, ScoreWithValue, ZRange }
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisSortedSetsDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.StringCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
@@ -17,10 +17,10 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.StringCommands
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.Redis
 
 object RedisStringsDemo extends LoggerIOApp {
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
@@ -18,11 +18,10 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.algebra.RedisCommands
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.hlist._
-import dev.profunktor.redis4cats.interpreter.Redis
 import dev.profunktor.redis4cats.transactions._
 import java.util.concurrent.TimeoutException
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.hlist._

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/StreamingDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/StreamingDemo.scala
@@ -20,8 +20,8 @@ import cats.effect.IO
 import cats.syntax.parallel._
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.interpreter.streams.RedisStream
-import dev.profunktor.redis4cats.streams.StreamingMessage
+import dev.profunktor.redis4cats.streams.RedisStream
+import dev.profunktor.redis4cats.streams.data.StreamingMessage
 import fs2.Stream
 
 import scala.concurrent.duration._

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/LivePubSubCommands.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/LivePubSubCommands.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter.pubsub
+package dev.profunktor.redis4cats
+package pubsub
 
 import cats.effect._
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
-import dev.profunktor.redis4cats.algebra.{ PubSubCommands, PubSubStats, SubscribeCommands }
-import dev.profunktor.redis4cats.domain.RedisChannel
-import dev.profunktor.redis4cats.interpreter.pubsub.internals.{ PubSubInternals, PubSubState }
-import dev.profunktor.redis4cats.streams.Subscription
+import dev.profunktor.redis4cats.data.RedisChannel
+import dev.profunktor.redis4cats.pubsub.data.Subscription
+import dev.profunktor.redis4cats.pubsub.internals.{ PubSubInternals, PubSubState }
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log }
 import fs2.Stream
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSub.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSub.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter.pubsub
+package dev.profunktor.redis4cats
+package pubsub
 
 import cats.effect._
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
-import dev.profunktor.redis4cats.algebra.{ PubSubCommands, PublishCommands, SubscribeCommands }
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.connection.RedisClient
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log }
 import dev.profunktor.redis4cats.effect.JRFuture._

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/Publisher.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/Publisher.scala
@@ -14,39 +14,34 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter.pubsub
+package dev.profunktor.redis4cats
+package pubsub
 
 import cats.effect._
-import cats.syntax.all._
-import dev.profunktor.redis4cats.algebra.PubSubStats
-import dev.profunktor.redis4cats.domain._
-import dev.profunktor.redis4cats.streams.Subscription
+import cats.syntax.functor._
+import dev.profunktor.redis4cats.data.RedisChannel
 import dev.profunktor.redis4cats.effect.JRFuture
+import dev.profunktor.redis4cats.pubsub.data.Subscription
 import fs2.Stream
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
 
-import dev.profunktor.redis4cats.JavaConversions._
-
-class LivePubSubStats[F[_]: Concurrent: ContextShift, K, V](
+class Publisher[F[_]: ConcurrentEffect: ContextShift, K, V](
     pubConnection: StatefulRedisPubSubConnection[K, V],
     blocker: Blocker
-) extends PubSubStats[Stream[F, *], K] {
+) extends PublishCommands[Stream[F, *], K, V] {
+
+  private[redis4cats] val pubSubStats: PubSubStats[Stream[F, *], K] = new LivePubSubStats(pubConnection, blocker)
+
+  override def publish(channel: RedisChannel[K]): Stream[F, V] => Stream[F, Unit] =
+    _.evalMap(message => JRFuture(F.delay(pubConnection.async().publish(channel.underlying, message)))(blocker).void)
 
   override def pubSubChannels: Stream[F, List[K]] =
-    Stream
-      .eval {
-        JRFuture(F.delay(pubConnection.async().pubsubChannels()))(blocker)
-      }
-      .map(_.asScala.toList)
+    pubSubStats.pubSubChannels
 
   override def pubSubSubscriptions(channel: RedisChannel[K]): Stream[F, Subscription[K]] =
-    pubSubSubscriptions(List(channel)).map(_.headOption).unNone
+    pubSubStats.pubSubSubscriptions(channel)
 
   override def pubSubSubscriptions(channels: List[RedisChannel[K]]): Stream[F, List[Subscription[K]]] =
-    Stream.eval {
-      JRFuture(F.delay(pubConnection.async().pubsubNumsub(channels.map(_.underlying): _*)))(blocker).flatMap { kv =>
-        F.delay(kv.asScala.toList.map { case (k, n) => Subscription(RedisChannel[K](k), n) })
-      }
-    }
+    pubSubStats.pubSubSubscriptions(channels)
 
 }

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/Subscriber.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/Subscriber.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter.pubsub
+package dev.profunktor.redis4cats
+package pubsub
 
 import cats.effect._
 import cats.effect.concurrent.Ref
 import cats.effect.implicits._
 import cats.syntax.all._
-import dev.profunktor.redis4cats.algebra.SubscribeCommands
-import dev.profunktor.redis4cats.interpreter.pubsub.internals.{ PubSubInternals, PubSubState }
-import dev.profunktor.redis4cats.domain.RedisChannel
+import dev.profunktor.redis4cats.pubsub.internals.{ PubSubInternals, PubSubState }
+import dev.profunktor.redis4cats.data.RedisChannel
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log }
 import fs2.Stream
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/data.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/data.scala
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.algebra
+package dev.profunktor.redis4cats.pubsub
 
-import dev.profunktor.redis4cats.data.KeyScanCursor
+import dev.profunktor.redis4cats.data.RedisChannel
+import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands
 
-import scala.concurrent.duration.FiniteDuration
+object data {
 
-trait KeyCommands[F[_], K] {
-  def del(key: K*): F[Unit]
-  def exists(key: K*): F[Boolean]
-  def expire(k: K, seconds: FiniteDuration): F[Unit]
-  def ttl(key: K): F[Option[FiniteDuration]]
-  def pttl(key: K): F[Option[FiniteDuration]]
-  def scan: F[KeyScanCursor[K]]
-  def scan(cursor: Long): F[KeyScanCursor[K]]
+  trait RedisPubSubCommands[K, V] {
+    def underlying: RedisPubSubAsyncCommands[K, V]
+  }
+  case class LivePubSubCommands[K, V](underlying: RedisPubSubAsyncCommands[K, V]) extends RedisPubSubCommands[K, V]
+
+  case class Subscription[K](channel: RedisChannel[K], number: Long)
+
+  object Subscription {
+    def empty[K](channel: RedisChannel[K]): Subscription[K] =
+      Subscription[K](channel, 0L)
+  }
+
 }

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubInternals.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubInternals.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter.pubsub.internals
+package dev.profunktor.redis4cats.pubsub.internals
 
 import cats.effect.ConcurrentEffect
 import cats.effect.concurrent.Ref
 import cats.effect.syntax.effect._
 import cats.syntax.all._
-import dev.profunktor.redis4cats.domain.RedisChannel
+import dev.profunktor.redis4cats.data.RedisChannel
 import dev.profunktor.redis4cats.effect.Log
 import fs2.concurrent.Topic
 import io.lettuce.core.pubsub.{ RedisPubSubListener, StatefulRedisPubSubConnection }

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/package.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/package.scala
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.algebra
+package dev.profunktor.redis4cats.pubsub
 
-import cats.effect.{ Concurrent, ContextShift }
+import dev.profunktor.redis4cats.data.RedisChannel
+import fs2.concurrent.Topic
 
-trait RedisCommands[F[_], K, V]
-    extends StringCommands[F, K, V]
-    with HashCommands[F, K, V]
-    with SetCommands[F, K, V]
-    with SortedSetCommands[F, K, V]
-    with ListCommands[F, K, V]
-    with GeoCommands[F, K, V]
-    with ConnectionCommands[F]
-    with ServerCommands[F, K]
-    with TransactionalCommands[F, K]
-    with PipelineCommands[F]
-    with ScriptCommands[F, K, V]
-    with KeyCommands[F, K] {
-  def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V]
+package object internals {
+  private[pubsub] type PubSubState[F[_], K, V] = Map[K, Topic[F, Option[V]]]
+  private[pubsub] type GetOrCreateTopicListener[F[_], K, V] =
+    RedisChannel[K] => PubSubState[F, K, V] => F[Topic[F, Option[V]]]
 }

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/pubsub.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/pubsub.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.algebra
+package dev.profunktor.redis4cats
+package pubsub
 
-import dev.profunktor.redis4cats.domain._
-import dev.profunktor.redis4cats.streams.Subscription
+import dev.profunktor.redis4cats.data._
+import dev.profunktor.redis4cats.pubsub.data.Subscription
 
 trait PubSubStats[F[_], K] {
   def pubSubChannels: F[List[K]]

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2RawStreaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2RawStreaming.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter.streams
+package dev.profunktor.redis4cats
+package streams
 
 import cats.effect._
 import cats.syntax.functor._
-import dev.profunktor.redis4cats.algebra.RawStreaming
-import dev.profunktor.redis4cats.streams._
 import dev.profunktor.redis4cats.effect.JRFuture
+import dev.profunktor.redis4cats.streams.data._
 import io.lettuce.core.XReadArgs.StreamOffset
 import io.lettuce.core.api.StatefulRedisConnection
 

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter.streams
+package dev.profunktor.redis4cats
+package streams
 
 import cats.effect._
 import cats.effect.concurrent.Ref
-import cats.instances.list._
-import cats.syntax.all._
-import dev.profunktor.redis4cats.algebra.Streaming
-import dev.profunktor.redis4cats.connection.RedisMasterReplica
-import dev.profunktor.redis4cats.domain._
-import dev.profunktor.redis4cats.connection.{ RedisClient, RedisURI }
+import cats.implicits._
+import dev.profunktor.redis4cats.connection._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.effect.{ JRFuture, Log }
 import dev.profunktor.redis4cats.effect.JRFuture._
-import dev.profunktor.redis4cats.streams._
+import dev.profunktor.redis4cats.streams.data._
 import fs2.Stream
 import io.lettuce.core.{ ReadFrom => JReadFrom }
 

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/data.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/data.scala
@@ -15,23 +15,9 @@
  */
 
 package dev.profunktor.redis4cats
+package streams
 
-import dev.profunktor.redis4cats.domain.RedisChannel
-import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands
-
-object streams {
-
-  trait RedisPubSubCommands[K, V] {
-    def underlying: RedisPubSubAsyncCommands[K, V]
-  }
-  case class LivePubSubCommands[K, V](underlying: RedisPubSubAsyncCommands[K, V]) extends RedisPubSubCommands[K, V]
-
-  case class Subscription[K](channel: RedisChannel[K], number: Long)
-
-  object Subscription {
-    def empty[K](channel: RedisChannel[K]): Subscription[K] =
-      Subscription[K](channel, 0L)
-  }
+object data {
 
   final case class StreamingMessage[K, V](key: K, body: Map[K, V])
   final case class StreamingMessageWithId[K, V](id: MessageId, key: K, body: Map[K, V])

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.interpreter.pubsub
+package dev.profunktor.redis4cats.streams
 
-import dev.profunktor.redis4cats.domain.RedisChannel
-import fs2.concurrent.Topic
+import data._
 
-package object internals {
-  private[pubsub] type PubSubState[F[_], K, V] = Map[K, Topic[F, Option[V]]]
-  private[pubsub] type GetOrCreateTopicListener[F[_], K, V] =
-    RedisChannel[K] => PubSubState[F, K, V] => F[Topic[F, Option[V]]]
+// format: off
+trait RawStreaming[F[_], K, V] {
+  def xAdd(key: K, body: Map[K, V]): F[MessageId]
+  def xRead(streams: Set[StreamingOffset[K]]): F[List[StreamingMessageWithId[K, V]]]
+}
+
+trait Streaming[F[_], K, V] {
+  def append: F[StreamingMessage[K, V]] => F[Unit]
+  def read(keys: Set[K], initialOffset: K => StreamingOffset[K] = StreamingOffset.All[K]): F[StreamingMessageWithId[K, V]]
 }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
@@ -18,11 +18,10 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.algebra._
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.domain.RedisCodec
+import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.effect.Log.NoOp._
-import dev.profunktor.redis4cats.interpreter.Redis
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.compatible.Assertion
 import org.scalatest.funsuite.AsyncFunSuite

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.effect.Log.NoOp._

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisClusterSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisClusterSpec.scala
@@ -16,7 +16,7 @@
 
 package dev.profunktor.redis4cats
 
-import dev.profunktor.redis4cats.domain.RedisCodec
+import dev.profunktor.redis4cats.data.RedisCodec
 
 class RedisClusterSpec extends Redis4CatsFunSuite(true) with TestScenarios {
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
@@ -16,7 +16,7 @@
 
 package dev.profunktor.redis4cats
 
-import dev.profunktor.redis4cats.domain.RedisCodec
+import dev.profunktor.redis4cats.data.RedisCodec
 import io.lettuce.core.codec.{ ToByteBufEncoder, RedisCodec => JRedisCodec, StringCodec => JStringCodec }
 import io.netty.buffer.ByteBuf
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -20,7 +20,6 @@ import java.time.Instant
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.algebra._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.effects._
 import dev.profunktor.redis4cats.hlist._

--- a/site/docs/effects/connection.md
+++ b/site/docs/effects/connection.md
@@ -11,15 +11,15 @@ Purely functional interface for the [Connection API](https://redis.io/commands#c
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
 import cats.implicits._
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ConnectionCommands
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, ConnectionCommands[IO]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ConnectionCommands[IO]]

--- a/site/docs/effects/geo.md
+++ b/site/docs/effects/geo.md
@@ -10,15 +10,15 @@ Purely functional interface for the [Geo API](https://redis.io/commands#geo).
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.GeoCommands
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 lazy val commandsApi: Resource[IO, GeoCommands[IO, String, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[GeoCommands[IO, String, String]])

--- a/site/docs/effects/hashes.md
+++ b/site/docs/effects/hashes.md
@@ -10,15 +10,15 @@ Purely functional interface for the [Hashes API](https://redis.io/commands#hash)
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.HashCommands
-import dev.profunktor.redis4cats.interpreter.Redis
 import dev.profunktor.redis4cats.log4cats._
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, HashCommands[IO, String, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[HashCommands[IO, String, String]])

--- a/site/docs/effects/index.md
+++ b/site/docs/effects/index.md
@@ -39,10 +39,10 @@ Here's an example of acquiring a client and a connection to the `Strings API`:
 
 ```scala mdoc:silent
 import cats.effect.{IO, Resource}
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.StringCommands
 import dev.profunktor.redis4cats.connection.{RedisClient, RedisURI}
-import dev.profunktor.redis4cats.domain.RedisCodec
-import dev.profunktor.redis4cats.interpreter.Redis
+import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -95,10 +95,10 @@ def apply[F[_], K, V](codec: RedisCodec[K, V], uris: RedisURI*)(
 ```scala mdoc:silent
 import cats.effect.{IO, Resource}
 import cats.implicits._
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.StringCommands
 import dev.profunktor.redis4cats.connection.RedisMasterReplica
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain.{ ReadFrom}
+import dev.profunktor.redis4cats.data.ReadFrom
 
 // Already imported above, but if copying from this block is necessary
 // val stringCodec: RedisCodec[String, String] = RedisCodec.Utf8

--- a/site/docs/effects/keys.md
+++ b/site/docs/effects/keys.md
@@ -10,16 +10,16 @@ Purely functional interface for the [Keys API](https://redis.io/commands#generic
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.KeyCommands
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import scala.concurrent.duration._
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, KeyCommands[IO, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[KeyCommands[IO, String]])

--- a/site/docs/effects/lists.md
+++ b/site/docs/effects/lists.md
@@ -10,15 +10,15 @@ Purely functional interface for the [Lists API](https://redis.io/commands#list).
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ListCommands
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, ListCommands[IO, String, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[ListCommands[IO, String, String]])

--- a/site/docs/effects/scripting.md
+++ b/site/docs/effects/scripting.md
@@ -11,10 +11,10 @@ Purely functional interface for the [Scripting API](https://redis.io/commands#sc
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
 import cats.implicits._
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ScriptCommands
 import dev.profunktor.redis4cats.effects.ScriptOutputType
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger

--- a/site/docs/effects/server.md
+++ b/site/docs/effects/server.md
@@ -11,15 +11,15 @@ Purely functional interface for the [Server API](https://redis.io/commands#serve
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
 import cats.implicits._
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ServerCommands
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, ServerCommands[IO, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ServerCommands[IO, String]]

--- a/site/docs/effects/sets.md
+++ b/site/docs/effects/sets.md
@@ -10,15 +10,15 @@ Purely functional interface for the [Sets API](https://redis.io/commands#set).
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.SetCommands
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, SetCommands[IO, String, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[SetCommands[IO, String, String]])

--- a/site/docs/effects/sortedsets.md
+++ b/site/docs/effects/sortedsets.md
@@ -10,15 +10,15 @@ Purely functional interface for the [Sorted Sets API](https://redis.io/commands#
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.SortedSetCommands
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, SortedSetCommands[IO, String, Long]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[SortedSetCommands[IO, String, Long]])

--- a/site/docs/effects/strings.md
+++ b/site/docs/effects/strings.md
@@ -10,15 +10,15 @@ Purely functional interface for the [Strings API](https://redis.io/commands#stri
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.StringCommands
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, StringCommands[IO, String, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[StringCommands[IO, String, String]])

--- a/site/docs/pipelining.md
+++ b/site/docs/pipelining.md
@@ -25,15 +25,14 @@ Note that every command has to be forked (`.start`) because the commands need to
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
-import dev.profunktor.redis4cats.algebra._
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, RedisCommands[IO, String, String]] = {
   Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]])

--- a/site/docs/streams/pubsub.md
+++ b/site/docs/streams/pubsub.md
@@ -25,7 +25,7 @@ Note: cluster support is not implemented yet.
 
 ### Subscriber
 
-```tut:silent
+```mdoc:silent
 trait SubscribeCommands[F[_], K, V] {
   def subscribe(channel: RedisChannel[K]): F[V]
   def unsubscribe(channel: RedisChannel[K]): F[Unit]
@@ -36,7 +36,7 @@ When using the `PubSub` interpreter the types will be `Stream[F, V]` and `Stream
 
 ### Publisher / PubSubStats
 
-```tut:silent
+```mdoc:silent
 trait PubSubStats[F[_], K] {
   def pubSubChannels: F[List[K]]
   def pubSubSubscriptions(channel: RedisChannel[K]): F[Subscription[K]]
@@ -56,8 +56,8 @@ When using the `PubSub` interpreter the `publish` function will be defined as a 
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.implicits._
 import dev.profunktor.redis4cats.connection.{ RedisClient, RedisURI }
-import dev.profunktor.redis4cats.domain._
-import dev.profunktor.redis4cats.interpreter.pubsub.PubSub
+import dev.profunktor.redis4cats.data._
+import dev.profunktor.redis4cats.pubsub.PubSub
 import dev.profunktor.redis4cats.log4cats._
 import fs2.{Pipe, Stream}
 import io.chrisdavenport.log4cats.Logger
@@ -68,7 +68,7 @@ import scala.util.Random
 
 object PubSubDemo extends IOApp {
 
-  implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
   private val stringCodec = RedisCodec.Utf8
 

--- a/site/docs/streams/streams.md
+++ b/site/docs/streams/streams.md
@@ -51,11 +51,12 @@ trait Streaming[F[_], K, V] {
 ```scala mdoc:silent
 import cats.effect.IO
 import cats.syntax.parallel._
+import dev.profunktor.redis4cats.RedisCommands
 import dev.profunktor.redis4cats.connection.{ RedisClient, RedisURI }
-import dev.profunktor.redis4cats.domain._
-import dev.profunktor.redis4cats.interpreter.streams.RedisStream
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
-import dev.profunktor.redis4cats.streams._
+import dev.profunktor.redis4cats.streams.RedisStream
+import dev.profunktor.redis4cats.streams.data._
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -65,7 +66,7 @@ import scala.util.Random
 
 implicit val timer = IO.timer(ExecutionContext.global)
 implicit val cs    = IO.contextShift(ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val stringCodec = RedisCodec.Utf8
 

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -24,9 +24,8 @@ Below you can find a first example of transactional commands.
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
-import dev.profunktor.redis4cats.algebra._
-import dev.profunktor.redis4cats.interpreter.Redis
-import dev.profunktor.redis4cats.domain._
+import dev.profunktor.redis4cats._
+import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger


### PR DESCRIPTION
I've been wanting to make these (breaking) changes like forever! 

### Main changes

 Before | Now 
---------- | ---------
`dev.profunktor.redis4cats.interpreter.Redis` | `dev.profunktor.redis4cats.Redis` 
`dev.profunktor.redis4cats.domain._` | `dev.profunktor.redis4cats.data._` 
`dev.profunktor.redis4cats.interpreter.pubsub.PubSub` | `dev.profunktor.redis4cats.pubsub.PubSub`
`dev.profunktor.redis4cats.interpreter.streams.RedisStream` | `dev.profunktor.redis4cats.streams.RedisStream`
`dev.profunktor.redis4cats.streams._` | `dev.profunktor.redis4cats.pubsub.data._` (*)
`dev.profunktor.redis4cats.streams._` | `dev.profunktor.redis4cats.streams.data._` (*)

(*) It has been split into two different files.

Once we are happy with the change, I'll try to make a `scalafix` so Scala Steward can easily automate the upgrade in other projects.
