### PR TITLE
Filter Unit types from HList

### DIFF
--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/hlist.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/hlist.scala
@@ -47,9 +47,9 @@ object hlist {
       def filterUnit[R <: HList](implicit w: Filter.Aux[T, R]): R = {
         def go(ys: HList, res: HList): HList =
           ys match {
-            case HNil                   => res
-            case HCons(h, t) if h == () => go(t, res)
-            case HCons(h, t)            => go(t, h :: res)
+            case HNil                                => res
+            case HCons(h, t) if h.isInstanceOf[Unit] => go(t, res)
+            case HCons(h, t)                         => go(t, h :: res)
           }
         go(t, HNil).reverse.asInstanceOf[w.R]
       }

--- a/modules/core/src/test/scala/dev/profunktor/redis4cats/HListSpec.scala
+++ b/modules/core/src/test/scala/dev/profunktor/redis4cats/HListSpec.scala
@@ -47,4 +47,16 @@ class HListSpec extends AnyFunSuite with Matchers {
     assert(n2.isInstanceOf[Int])
   }
 
+  test("Filter out values") {
+    val unit = ()
+    val hl   = unit :: "hi" :: 33 :: unit :: false :: 's' :: unit :: HNil
+
+    val s ~: n ~: b ~: c ~: HNil = hl.filterUnit
+
+    assert(s.isInstanceOf[String])
+    assert(n.isInstanceOf[Int])
+    assert(b.isInstanceOf[Boolean])
+    assert(c.isInstanceOf[Char])
+  }
+
 }

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
@@ -54,9 +54,9 @@ object RedisPipelineDemo extends LoggerIOApp {
 
         val prog =
           RedisPipeline(cmd)
-            .exec(operations)
+            .exec_(operations)
             .flatMap {
-              case _ ~: _ ~: res1 ~: _ ~: _ ~: res2 ~: HNil =>
+              case res1 ~: res2 ~: HNil =>
                 putStrLn(s"res1: $res1, res2: $res2")
             }
             .onError {

--- a/site/docs/pipelining.md
+++ b/site/docs/pipelining.md
@@ -17,7 +17,7 @@ Use [pipelining](https://redis.io/topics/pipelining) to speed up your queries by
 
 ### RedisPipeline usage
 
-The API for disabling / enabling autoflush and flush commands manually is available for you to use but since the pattern is so common it is recommended to just use `RedisPipeline`. You can create a pipeline by passing the commands API as a parameter and invoke the `exec` function given the set of commands you wish to send to the server.
+The API for disabling / enabling autoflush and flush commands manually is available for you to use but since the pattern is so common it is recommended to just use `RedisPipeline`. You can create a pipeline by passing the commands API as a parameter and invoke the `exec` function (or `exec_`) given the set of commands you wish to send to the server.
 
 Note that every command has to be forked (`.start`) because the commands need to be sent to the server in an asynchronous way but no response will be received until the commands are successfully flushed. Also, it is not possible to sequence commands (`flatMap`) that are part of a pipeline. Every command has to be atomic and independent of previous results.
 
@@ -68,9 +68,9 @@ commandsApi.use { cmd => // RedisCommands[IO, String, String]
 
   val prog =
     RedisPipeline(cmd)
-      .exec(operations)
+      .exec_(operations)
       .flatMap {
-        case _ ~: _ ~: res1 ~: _ ~: _ ~: res2 ~: HNil =>
+        case res1 ~: res2 ~: HNil =>
           putStrLn(s"res1: $res1, res2: $res2")
       }
       .onError {
@@ -83,4 +83,6 @@ commandsApi.use { cmd => // RedisCommands[IO, String, String]
   getters >> prog >> getters >> putStrLn("keep doing stuff...")
 }
 ```
+
+The `exec_` function filters out values of type `Unit`, which are normally irrelevant. If you find yourself needing the `Unit` types to verify some behavior, use `exec` instead.
 

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -16,7 +16,7 @@ and handle the possible errors and retry logic.
 
 ### Working with transactions
 
-The most common way is to create a `RedisTransaction` once by passing the commands API as a parameter and invoke the `exec` function every time you want to run the given commands as part of a new transaction.
+The most common way is to create a `RedisTransaction` once by passing the commands API as a parameter and invoke the `exec` function (or `exec_`) every time you want to run the given commands as part of a new transaction.
 
 Every command has to be atomic and independent of previous Redis results, so it is not recommended to chain commands using `flatMap`.
 
@@ -70,9 +70,9 @@ commandsApi.use { cmd => // RedisCommands[IO, String, String]
   // the result type is inferred as well
   // Unit :: Option[String] :: Unit :: HNil
   val prog =
-    tx.exec(commands)
+    tx.exec_(commands)
       .flatMap {
-        case _ ~: res1 ~: _ ~: HNil =>
+        case res1 ~: HNil =>
           putStrLn(s"Key1 result: $res1")
       }
       .onError {
@@ -95,6 +95,8 @@ Transactional commands may be discarded if something went wrong in between. The 
 - `TransactionDiscarded`: The `EXEC` command failed and the transactional commands were discarded.
 - `TransactionAborted`: The `DISCARD` command was triggered due to cancellation or other failure within the transaction.
 - `TimeoutException`: The transaction timed out due to some unknown error.
+
+The `exec_` function filters out values of type `Unit`, which are normally irrelevant. If you find yourself needing the `Unit` types to verify some behavior, use `exec` instead.
 
 ### How NOT to use transactions
 


### PR DESCRIPTION
Having the possibility to discard `Unit` types from an `HList` is quite useful for transactions and pipelining, since normally one wouldn't care about the result of a `SET`.

This PR adds a new function `exec_` for transactions and pipelining, which actually filters out values of type `Unit`, giving us the power to do this:

```scala
val operations =
  cmd.set(key1, "noop") :: cmd.set(key2, "windows") :: cmd.get(key1) ::
      cmd.set(key1, "nix") :: cmd.set(key2, "linux") :: cmd.get(key1) :: HNil

val prog =
  RedisPipeline(cmd)
    .exec_(operations)
    .flatMap {
      case res1 ~: res2 ~: HNil =>
        putStrLn(s"res1: $res1, res2: $res2")
    }
```

Whereas using `exec` would preserve the values of type `Unit`:

```scala
val operations =
  cmd.set(key1, "noop") :: cmd.set(key2, "windows") :: cmd.get(key1) ::
      cmd.set(key1, "nix") :: cmd.set(key2, "linux") :: cmd.get(key1) :: HNil

val prog =
  RedisPipeline(cmd)
    .exec(operations)
    .flatMap {
      case _ ~: _ ~: res1 ~: _ ~: _ ~: res2 ~: HNil =>
        putStrLn(s"res1: $res1, res2: $res2")
    }
```

It is also possible to call `filterUnit` on an `HList`, if needed.