### PR TITLE
Renaming exec_ with filterExec

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/runner.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/runner.scala
@@ -42,6 +42,11 @@ object Runner {
 
 private[redis4cats] class RunnerPartiallyApplied[F[_]: Concurrent: Log: Timer] {
 
+  def filterExec[T <: HList, R <: HList, S <: HList](ops: Runner.Ops[F])(commands: T)(
+      implicit w: Witness.Aux[T, R],
+      f: Filter.Aux[R, S]
+  ): F[S] = exec[T, R](ops)(commands).map(_.filterUnit)
+
   def exec[T <: HList, R <: HList](ops: Runner.Ops[F])(commands: T)(implicit w: Witness.Aux[T, R]): F[R] =
     Deferred[F, Either[Throwable, w.R]].flatMap { promise =>
       def cancelFibers[A](fibs: HList)(err: Throwable): F[Unit] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
@@ -54,7 +54,7 @@ object RedisPipelineDemo extends LoggerIOApp {
 
         val prog =
           RedisPipeline(cmd)
-            .exec_(operations)
+            .filterExec(operations)
             .flatMap {
               case res1 ~: res2 ~: HNil =>
                 putStrLn(s"res1: $res1, res2: $res2")

--- a/site/docs/pipelining.md
+++ b/site/docs/pipelining.md
@@ -17,7 +17,7 @@ Use [pipelining](https://redis.io/topics/pipelining) to speed up your queries by
 
 ### RedisPipeline usage
 
-The API for disabling / enabling autoflush and flush commands manually is available for you to use but since the pattern is so common it is recommended to just use `RedisPipeline`. You can create a pipeline by passing the commands API as a parameter and invoke the `exec` function (or `exec_`) given the set of commands you wish to send to the server.
+The API for disabling / enabling autoflush and flush commands manually is available for you to use but since the pattern is so common it is recommended to just use `RedisPipeline`. You can create a pipeline by passing the commands API as a parameter and invoke the `exec` function (or `filterExec`) given the set of commands you wish to send to the server.
 
 Note that every command has to be forked (`.start`) because the commands need to be sent to the server in an asynchronous way but no response will be received until the commands are successfully flushed. Also, it is not possible to sequence commands (`flatMap`) that are part of a pipeline. Every command has to be atomic and independent of previous results.
 
@@ -68,7 +68,7 @@ commandsApi.use { cmd => // RedisCommands[IO, String, String]
 
   val prog =
     RedisPipeline(cmd)
-      .exec_(operations)
+      .filterExec(operations)
       .flatMap {
         case res1 ~: res2 ~: HNil =>
           putStrLn(s"res1: $res1, res2: $res2")
@@ -84,5 +84,4 @@ commandsApi.use { cmd => // RedisCommands[IO, String, String]
 }
 ```
 
-The `exec_` function filters out values of type `Unit`, which are normally irrelevant. If you find yourself needing the `Unit` types to verify some behavior, use `exec` instead.
-
+The `filterExec` function filters out values of type `Unit`, which are normally irrelevant. If you find yourself needing the `Unit` types to verify some behavior, use `exec` instead.

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -16,7 +16,7 @@ and handle the possible errors and retry logic.
 
 ### Working with transactions
 
-The most common way is to create a `RedisTransaction` once by passing the commands API as a parameter and invoke the `exec` function (or `exec_`) every time you want to run the given commands as part of a new transaction.
+The most common way is to create a `RedisTransaction` once by passing the commands API as a parameter and invoke the `exec` function (or `filterExec`) every time you want to run the given commands as part of a new transaction.
 
 Every command has to be atomic and independent of previous Redis results, so it is not recommended to chain commands using `flatMap`.
 
@@ -70,7 +70,7 @@ commandsApi.use { cmd => // RedisCommands[IO, String, String]
   // the result type is inferred as well
   // Unit :: Option[String] :: Unit :: HNil
   val prog =
-    tx.exec_(commands)
+    tx.filterExec(commands)
       .flatMap {
         case res1 ~: HNil =>
           putStrLn(s"Key1 result: $res1")
@@ -96,7 +96,7 @@ Transactional commands may be discarded if something went wrong in between. The 
 - `TransactionAborted`: The `DISCARD` command was triggered due to cancellation or other failure within the transaction.
 - `TimeoutException`: The transaction timed out due to some unknown error.
 
-The `exec_` function filters out values of type `Unit`, which are normally irrelevant. If you find yourself needing the `Unit` types to verify some behavior, use `exec` instead.
+The `filterExec` function filters out values of type `Unit`, which are normally irrelevant. If you find yourself needing the `Unit` types to verify some behavior, use `exec` instead.
 
 ### How NOT to use transactions
 


### PR DESCRIPTION
I figured `filterExec` is a better name for "execute" and "filter out" values than `exec_`, which following conventions (such as `traverse_` and `sequence_`) would mean discard its value instead of filtering some values out.