### PR TITLE
Simplifying API and improving type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,48 +9,47 @@ redis4cats
 
 Redis client built on top of [Cats Effect](https://typelevel.org/cats-effect/), [Fs2](http://fs2.io/) and the async Java client [Lettuce](https://lettuce.io/).
 
-> **NOTE**: Neither binary compatibility nor API stability will be guaranteed until we reach `1.0.0`.
+### Quick Start
 
-`redis4cats` defines two types of API: an effect-based using [Cats Effect](https://typelevel.org/cats-effect/) and a stream-based using [Fs2](http://fs2.io/).
+```scala
+import cats.effect._
+import cats.implicits._
+import dev.profunktor.redis4cats.Redis
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
-### Effects
+object QuickStart extends IOApp {
 
-- [Connection API](https://redis.io/commands#connection): `ping`
-- [Geo API](https://redis.io/commands#geo): `geoadd`, `geohash`, `geopos`, `geodist`, etc.
-- [Hashes API](https://redis.io/commands#hash): `hgetall`, `hset`, `hdel`, `hincrby`, etc.
-- [Keys API](https://redis.io/commands#generic): `del`, `expire`, `exists`, etc.
-- [Lists API](https://redis.io/commands#list): `rpush`, `lrange`, `lpop`, etc.
-- [Scripting API](https://redis.io/commands#scripting): `eval`, `evalsha`, etc.
-- [Server API](https://redis.io/commands#server): `flushall`, etc.
-- [Sets API](https://redis.io/commands#set): `sadd`, `scard`, `srem`, `spop`, etc.
-- [Sorted Sets API](https://redis.io/commands#sorted_set): `zcount`, `zcard`, `zrangebyscore`, `zrank`, etc.
-- [Strings API](https://redis.io/commands#string): `get`, `set`, etc.
+  override def run(args: List[String]): IO[ExitCode] =
+    Redis[IO].utf8("redis://localhost").use { cmd =>
+      for {
+        _ <- cmd.set("foo", "123")
+        x <- cmd.get("foo")
+        _ <- cmd.setNx("foo", "should not happen")
+        y <- cmd.get("foo")
+        _ <- IO(println(x === y)) // true
+      } yield ExitCode.Success
+    }
 
-### Streams
+}
+```
 
-- [PubSub API](https://redis.io/topics/pubsub) implemented on top of `fs2` streams.
-- [Streams API](https://redis.io/topics/streams-intro) experimental API, subject to changes.
-  + High-level API offers `read` and `append` using the underlying commands `XREAD` and `XADD` respectively.
-  + Consumer Groups are yet not implemented.
+The API is quite stable and *heavily used in production*. However, binary compatibility won't be guaranteed until we reach `1.0.0`.
 
-Other features are not considered at the moment but PRs and suggestions are very welcome.
+If you like it, give it a :star:! If you think we could do better, please [let us know](https://gitter.im/profunktor-dev/redis4cats)!
 
-## Dependencies
+### Dependencies
 
-Add this to your `build.sbt` for the Effects API (depends on `cats-effect`):
+Add this to your `build.sbt` for the [Effects API](https://redis4cats.profunktor.dev/effects/) (depends on `cats-effect`):
 
 ```
 libraryDependencies += "dev.profunktor" %% "redis4cats-effects" % Version
 ```
 
-And this for the Streams API (depends on `fs2` and `cats-effect`):
+Add this for the [Streams API](https://redis4cats.profunktor.dev/streams/) (depends on `fs2` and `cats-effect`):
 
 ```
 libraryDependencies += "dev.profunktor" %% "redis4cats-streams" % Version
 ```
-
-Note: previous artifacts `<= 0.8.0-RC1` were published using the `com.github.gvolpe` group id (see [migration
-guide](https://github.com/profunktor/redis4cats/wiki/Migration-guide-(Vim))).
 
 ### Log4cats support
 
@@ -60,8 +59,9 @@ guide](https://github.com/profunktor/redis4cats/wiki/Migration-guide-(Vim))).
 libraryDependencies += "dev.profunktor" %% "redis4cats-log4cats" % Version
 ```
 
-## Documentation
-Guides and examples can be found on the [micro site](https://redis4cats.profunktor.dev).
+## Scala docs
+
+Guides and examples can be found on the [microsite](https://redis4cats.profunktor.dev).
 
 The scala docs can be found here by module:
 * Core [![javadoc](https://javadoc.io/badge2/dev.profunktor/redis4cats-core_2.13/javadoc.svg)](https://javadoc.io/doc/dev.profunktor/redis4cats-core_2.13)

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.StringCommands
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 
 object RedisClusterStringsDemo extends LoggerIOApp {
@@ -32,11 +31,7 @@ object RedisClusterStringsDemo extends LoggerIOApp {
       _.fold(putStrLn(s"Not found key: $usernameKey"))(s => putStrLn(s))
 
     val commandsApi: Resource[IO, StringCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisClusterURI))
-        client <- RedisClusterClient[IO](uri)
-        redis <- Redis.cluster[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].clusterUtf8(redisClusterURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
@@ -36,7 +36,7 @@ object RedisClusterTransactionsDemo extends LoggerIOApp {
       for {
         uri <- Resource.liftF(RedisURI.make[IO](redisClusterURI))
         client <- RedisClusterClient[IO](uri)
-        redis <- Redis.cluster[IO, String, String](client, stringCodec)
+        redis <- Redis[IO].makeCluster(client, stringCodec)
       } yield client -> redis
 
     commandsApi
@@ -46,7 +46,7 @@ object RedisClusterTransactionsDemo extends LoggerIOApp {
             for {
               _ <- Resource.liftF(cmd.set(key1, "empty"))
               nodeId <- Resource.liftF(RedisClusterClient.nodeId[IO](client, key1))
-              nodeCmd <- Redis.clusterByNode[IO, String, String](client, stringCodec, nodeId)
+              nodeCmd <- Redis[IO].makeClusterByNode(client, stringCodec, nodeId)
             } yield nodeCmd
 
           // Transactions are only supported on a single node

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.GeoCommands
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.effects._
 import io.lettuce.core.GeoArgs
@@ -31,11 +30,7 @@ object RedisGeoDemo extends LoggerIOApp {
     val testKey = "location"
 
     val commandsApi: Resource[IO, GeoCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     val _BuenosAires  = GeoLocation(Longitude(-58.3816), Latitude(-34.6037), "Buenos Aires")
     val _RioDeJaneiro = GeoLocation(Longitude(-43.1729), Latitude(-22.9068), "Rio de Janeiro")

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.HashCommands
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 
 object RedisHashesDemo extends LoggerIOApp {
@@ -33,11 +32,7 @@ object RedisHashesDemo extends LoggerIOApp {
       _.fold(putStrLn(s"Not found key: $testKey | field: $testField"))(s => putStrLn(s))
 
     val commandsApi: Resource[IO, HashCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.{ KeyCommands, StringCommands }
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 
 object RedisKeysDemo extends LoggerIOApp {
@@ -32,11 +31,7 @@ object RedisKeysDemo extends LoggerIOApp {
       _.fold(putStrLn(s"Not found key: $usernameKey"))(s => putStrLn(s))
 
     val commandsApi: Resource[IO, KeyCommands[IO, String] with StringCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.ListCommands
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 
 object RedisListsDemo extends LoggerIOApp {
@@ -29,11 +28,7 @@ object RedisListsDemo extends LoggerIOApp {
     val testKey = "listos"
 
     val commandsApi: Resource[IO, ListCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
@@ -34,8 +34,8 @@ object RedisMasterReplicaStringsDemo extends LoggerIOApp {
     val connection: Resource[IO, RedisCommands[IO, String, String]] =
       for {
         uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        conn <- RedisMasterReplica[IO, String, String](stringCodec, uri)(Some(ReadFrom.MasterPreferred))
-        cmds <- Redis.masterReplica[IO, String, String](conn)
+        conn <- RedisMasterReplica[IO].make(stringCodec, uri)(Some(ReadFrom.MasterPreferred))
+        cmds <- Redis[IO].masterReplica(conn)
       } yield cmds
 
     connection

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.hlist._
 import dev.profunktor.redis4cats.pipeline._
@@ -36,11 +35,7 @@ object RedisPipelineDemo extends LoggerIOApp {
       _.fold(putStrLn(s"Not found key: $key"))(s => putStrLn(s"$key: $s"))
 
     val commandsApi: Resource[IO, RedisCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.ScriptCommands
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.effects.ScriptOutputType
 
@@ -28,11 +27,7 @@ object RedisScriptsDemo extends LoggerIOApp {
 
   def program(implicit log: Log[IO]): IO[Unit] = {
     val commandsApi: Resource[IO, ScriptCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.SetCommands
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 
 object RedisSetsDemo extends LoggerIOApp {
@@ -31,11 +30,7 @@ object RedisSetsDemo extends LoggerIOApp {
     val showResult: Set[String] => IO[Unit] = x => putStrLn(s"$testKey members: $x")
 
     val commandsApi: Resource[IO, SetCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.SortedSetCommands
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.effects.{ Score, ScoreWithValue, ZRange }
 
@@ -30,11 +29,7 @@ object RedisSortedSetsDemo extends LoggerIOApp {
     val testKey = "zztop"
 
     val commandsApi: Resource[IO, SortedSetCommands[IO, String, Long]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, Long](client, longCodec)
-      } yield redis
+      Redis[IO].simple(redisURI, longCodec)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.StringCommands
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 
 object RedisStringsDemo extends LoggerIOApp {
@@ -32,11 +31,7 @@ object RedisStringsDemo extends LoggerIOApp {
       _.fold(putStrLn(s"Not found key: $usernameKey"))(s => putStrLn(s))
 
     val commandsApi: Resource[IO, StringCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
@@ -18,7 +18,6 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.hlist._
 import dev.profunktor.redis4cats.transactions._
@@ -36,11 +35,7 @@ object RedisTransactionsDemo extends LoggerIOApp {
       _.fold(putStrLn(s"Not found key: $key"))(s => putStrLn(s"$key: $s"))
 
     val commandsApi: Resource[IO, RedisCommands[IO, String, String]] =
-      for {
-        uri <- Resource.liftF(RedisURI.make[IO](redisURI))
-        client <- RedisClient[IO](uri)
-        redis <- Redis[IO, String, String](client, stringCodec)
-      } yield redis
+      Redis[IO].utf8(redisURI)
 
     commandsApi
       .use { cmd =>

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
@@ -53,7 +53,7 @@ object RedisStream {
       uris: RedisURI*
   )(readFrom: Option[JReadFrom] = None): Stream[F, Streaming[Stream[F, *], K, V]] =
     Stream.resource(mkBlocker[F]).flatMap { blocker =>
-      Stream.resource(RedisMasterReplica[F, K, V](codec, uris: _*)(readFrom)).map { conn =>
+      Stream.resource(RedisMasterReplica[F].make(codec, uris: _*)(readFrom)).map { conn =>
         new RedisStream(new RedisRawStreaming(conn.underlying, blocker))
       }
     }

--- a/site/docs/effects/connection.md
+++ b/site/docs/effects/connection.md
@@ -22,7 +22,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, ConnectionCommands[IO]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ConnectionCommands[IO]]
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ConnectionCommands[IO]]
 }
 ```
 

--- a/site/docs/effects/geo.md
+++ b/site/docs/effects/geo.md
@@ -10,6 +10,7 @@ Purely functional interface for the [Geo API](https://redis.io/commands#geo).
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.GeoCommands
 import dev.profunktor.redis4cats.data._
@@ -20,8 +21,8 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
-lazy val commandsApi: Resource[IO, GeoCommands[IO, String, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[GeoCommands[IO, String, String]])
+val commandsApi: Resource[IO, GeoCommands[IO, String, String]] = {
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[GeoCommands[IO, String, String]]
 }
 ```
 

--- a/site/docs/effects/hashes.md
+++ b/site/docs/effects/hashes.md
@@ -10,6 +10,7 @@ Purely functional interface for the [Hashes API](https://redis.io/commands#hash)
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.HashCommands
 import dev.profunktor.redis4cats.log4cats._
@@ -21,7 +22,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, HashCommands[IO, String, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[HashCommands[IO, String, String]])
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[HashCommands[IO, String, String]]
 }
 ```
 

--- a/site/docs/effects/keys.md
+++ b/site/docs/effects/keys.md
@@ -10,6 +10,7 @@ Purely functional interface for the [Keys API](https://redis.io/commands#generic
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.KeyCommands
 import dev.profunktor.redis4cats.data._
@@ -22,7 +23,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, KeyCommands[IO, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[KeyCommands[IO, String]])
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[KeyCommands[IO, String]]
 }
 ```
 

--- a/site/docs/effects/lists.md
+++ b/site/docs/effects/lists.md
@@ -10,6 +10,7 @@ Purely functional interface for the [Lists API](https://redis.io/commands#list).
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.ListCommands
 import dev.profunktor.redis4cats.data._
@@ -21,7 +22,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, ListCommands[IO, String, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[ListCommands[IO, String, String]])
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ListCommands[IO, String, String]]
 }
 ```
 

--- a/site/docs/effects/scripting.md
+++ b/site/docs/effects/scripting.md
@@ -23,7 +23,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, ScriptCommands[IO, String, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ScriptCommands[IO, String, String]]
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ScriptCommands[IO, String, String]]
 }
 ```
 

--- a/site/docs/effects/server.md
+++ b/site/docs/effects/server.md
@@ -22,7 +22,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, ServerCommands[IO, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ServerCommands[IO, String]]
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[ServerCommands[IO, String]]
 }
 ```
 

--- a/site/docs/effects/sets.md
+++ b/site/docs/effects/sets.md
@@ -10,6 +10,7 @@ Purely functional interface for the [Sets API](https://redis.io/commands#set).
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.SetCommands
 import dev.profunktor.redis4cats.data._
@@ -21,7 +22,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, SetCommands[IO, String, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[SetCommands[IO, String, String]])
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[SetCommands[IO, String, String]]
 }
 ```
 

--- a/site/docs/effects/sortedsets.md
+++ b/site/docs/effects/sortedsets.md
@@ -10,6 +10,7 @@ Purely functional interface for the [Sorted Sets API](https://redis.io/commands#
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.SortedSetCommands
 import dev.profunktor.redis4cats.data._
@@ -21,7 +22,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, SortedSetCommands[IO, String, Long]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[SortedSetCommands[IO, String, Long]])
+  Redis[IO].make[String, Long](null, null.asInstanceOf[RedisCodec[String, Long]]).widen[SortedSetCommands[IO, String, Long]]
 }
 ```
 

--- a/site/docs/effects/strings.md
+++ b/site/docs/effects/strings.md
@@ -10,6 +10,7 @@ Purely functional interface for the [Strings API](https://redis.io/commands#stri
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.algebra.StringCommands
 import dev.profunktor.redis4cats.data._
@@ -21,7 +22,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, StringCommands[IO, String, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]]).map(_.asInstanceOf[StringCommands[IO, String, String]])
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[StringCommands[IO, String, String]]
 }
 ```
 

--- a/site/docs/pipelining.md
+++ b/site/docs/pipelining.md
@@ -2,7 +2,7 @@
 layout: docs
 title:  "Pipelining"
 number: 5
-position: 4
+position: 5
 ---
 
 # Pipelining
@@ -23,6 +23,7 @@ Note that every command has to be forked (`.start`) because the commands need to
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats._
 import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
@@ -33,7 +34,7 @@ implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, RedisCommands[IO, String, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]])
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]])
 }
 ```
 
@@ -44,7 +45,6 @@ import dev.profunktor.redis4cats._
 import dev.profunktor.redis4cats.hlist._
 import dev.profunktor.redis4cats.pipeline._
 import java.util.concurrent.TimeoutException
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 
 implicit val timer = IO.timer(ExecutionContext.global)

--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -1,0 +1,32 @@
+---
+layout: docs
+title:  "Quick Start"
+number: 1
+position: 1
+---
+
+# Quick Start
+
+```scala mdoc:silent
+import cats.effect._
+import cats.implicits._
+import dev.profunktor.redis4cats.Redis
+import dev.profunktor.redis4cats.effect.Log.NoOp._ // disable logging
+
+object QuickStart extends IOApp {
+
+  override def run(args: List[String]): IO[ExitCode] =
+    Redis[IO].utf8("redis://localhost").use { cmd =>
+      for {
+        _ <- cmd.set("foo", "123")
+        x <- cmd.get("foo")
+        _ <- cmd.setNx("foo", "should not happen")
+        y <- cmd.get("foo")
+        _ <- IO(println(x === y)) // true
+      } yield ExitCode.Success
+    }
+
+}
+```
+
+This is the simplest way to get up and running with a single-node Redis connection. To learn more about commands, clustering, pipelining and transactions, please have a look at the extensive documentation.

--- a/site/docs/streams/index.md
+++ b/site/docs/streams/index.md
@@ -1,8 +1,8 @@
 ---
 layout: docs
 title:  "Streams API"
-number: 2
-position: 2
+number: 3
+position: 3
 ---
 
 # Streams API

--- a/site/docs/streams/pubsub.md
+++ b/site/docs/streams/pubsub.md
@@ -54,7 +54,6 @@ When using the `PubSub` interpreter the `publish` function will be defined as a 
 
 ```scala mdoc:silent
 import cats.effect.{ExitCode, IO, IOApp}
-import cats.implicits._
 import dev.profunktor.redis4cats.connection.{ RedisClient, RedisURI }
 import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.pubsub.PubSub

--- a/site/docs/streams/streams.md
+++ b/site/docs/streams/streams.md
@@ -51,7 +51,6 @@ trait Streaming[F[_], K, V] {
 ```scala mdoc:silent
 import cats.effect.IO
 import cats.syntax.parallel._
-import dev.profunktor.redis4cats.RedisCommands
 import dev.profunktor.redis4cats.connection.{ RedisClient, RedisURI }
 import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -2,7 +2,7 @@
 layout: docs
 title:  "Transactions"
 number: 4
-position: 3
+position: 4
 ---
 
 # Transactions
@@ -24,6 +24,7 @@ Below you can find a first example of transactional commands.
 
 ```scala mdoc:invisible
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import dev.profunktor.redis4cats._
 import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
@@ -36,7 +37,7 @@ implicit val timer = IO.timer(ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val commandsApi: Resource[IO, RedisCommands[IO, String, String]] = {
-  Redis[IO, String, String](null, null.asInstanceOf[RedisCodec[String, String]])
+  Redis[IO].make[String, String](null, null.asInstanceOf[RedisCodec[String, String]])
 }
 ```
 

--- a/site/src/main/resources/microsite/data/menu.yml
+++ b/site/src/main/resources/microsite/data/menu.yml
@@ -1,4 +1,8 @@
 options:
+  - title: Quick Start
+    url: quickstart.html
+    menu_section: quickstart
+
   - title: Effects API
     url: effects/
     menu_section: effectapi
@@ -58,10 +62,9 @@ options:
         menu_section: streamapi
 
   - title: Transactions
-    url: transactions
+    url: transactions.html
     menu_section: transactions
 
   - title: Pipelining
-    url: pipelining
+    url: pipelining.html
     menu_section: pipelining
-


### PR DESCRIPTION
Making it easier to get started for those who have a simple use case (the vast majority). Here's an example, which is now part of the new Quick Start section in the docs:

```scala
import cats.effect._
import cats.implicits._
import dev.profunktor.redis4cats.Redis
import dev.profunktor.redis4cats.effect.Log.NoOp._

object QuickStart extends IOApp {

  override def run(args: List[String]): IO[ExitCode] =
    Redis[IO].utf8("redis://localhost").use { cmd =>
      for {
        _ <- cmd.set("foo", "123")
        x <- cmd.get("foo")
        _ <- cmd.setNx("foo", "should not happen")
        y <- cmd.get("foo")
        _ <- IO(println(x === y)) // true
      } yield ExitCode.Success
    }

}
```

Overall the documentation has been improved as well.

### New constructors

- `Redis[IO].utf8("redis://localhost")`
- `Redis[IO].simple("redis://localhost", longCodec)`
- `Redis[IO].clusterUtf8("redis://localhost:30001")`
- `Redis[IO].cluster("redis://localhost:30001", someCodec)`

This greatly simplifies the creation of `RedisCommands[F, K, V]` while improving type inference (note that `K` and `V` are inferred from the codec passed as an argument) thanks to the *partially applied* trick.