### PR TITLE
Renaming noop logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Redis client built on top of [Cats Effect](https://typelevel.org/cats-effect/), 
 import cats.effect._
 import cats.implicits._
 import dev.profunktor.redis4cats.Redis
-import dev.profunktor.redis4cats.effect.Log.NoOp._
+import dev.profunktor.redis4cats.effect.Log.noop
 
 object QuickStart extends IOApp {
 

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/Log.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/Log.scala
@@ -16,7 +16,7 @@
 
 package dev.profunktor.redis4cats.effect
 
-import cats.Applicative
+import cats.effect.IO
 
 /**
   * Typeclass used for internal logging such as acquiring and releasing connections.
@@ -31,11 +31,9 @@ trait Log[F[_]] {
 object Log {
   def apply[F[_]](implicit ev: Log[F]): Log[F] = ev
 
-  object NoOp {
-    implicit def instance[F[_]: Applicative]: Log[F] =
-      new Log[F] {
-        def info(msg: => String): F[Unit]  = F.unit
-        def error(msg: => String): F[Unit] = F.unit
-      }
+  implicit object noop extends Log[IO] {
+    def info(msg: => String): IO[Unit]  = IO.unit
+    def error(msg: => String): IO[Unit] = IO.unit
   }
+
 }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
@@ -20,7 +20,7 @@ import cats.effect._
 import cats.implicits._
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data.RedisCodec
-import dev.profunktor.redis4cats.effect.Log.NoOp._
+import dev.profunktor.redis4cats.effect.Log.noop
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.compatible.Assertion
 import org.scalatest.funsuite.AsyncFunSuite

--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -11,7 +11,7 @@ position: 1
 import cats.effect._
 import cats.implicits._
 import dev.profunktor.redis4cats.Redis
-import dev.profunktor.redis4cats.effect.Log.NoOp._ // disable logging
+import dev.profunktor.redis4cats.effect.Log.noop // disable logging
 
 object QuickStart extends IOApp {
 


### PR DESCRIPTION
Internal logging is mainly used to log the status of connections so we don't need a `noop` instance for every `Applicative[F]`, one for `IO` is enough and slightly reduces the import syntax.