### PR TITLE
Stdout logging + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Redis client built on top of [Cats Effect](https://typelevel.org/cats-effect/), 
 import cats.effect._
 import cats.implicits._
 import dev.profunktor.redis4cats.Redis
-import dev.profunktor.redis4cats.effect.Log.noop
+import dev.profunktor.redis4cats.effect.Log.Stdout._
 
 object QuickStart extends IOApp {
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
@@ -20,7 +20,7 @@ import cats.effect._
 import cats.implicits._
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data.RedisCodec
-import dev.profunktor.redis4cats.effect.Log.noop
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import munit.FunSuite
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.Duration

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -20,7 +20,7 @@ import java.time.Instant
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.effect.Log.noop
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.effects._
 import dev.profunktor.redis4cats.hlist._
 import dev.profunktor.redis4cats.pipeline.RedisPipeline

--- a/site/docs/effects/index.md
+++ b/site/docs/effects/index.md
@@ -29,9 +29,25 @@ def apply[F[_]](uri: RedisURI): Resource[F, RedisClient]
 
 ### Logger
 
-In order to create a client and/or connection you must provide a `Log` instance that the library uses for internal logging. You could either create your own or use `log4cats` (recommended). `redis4cats` can derive an instance of `Log[F]` if there is an instance of `Logger[F]` in scope, just need to add the extra dependency `redis4cats-log4cats` and `import dev.profunktor.redis4cats.log4cats._`.
+In order to create a client and/or connection you must provide a `Log` instance that the library uses for internal logging. You could either use `log4cats` (recommended), one of the simpler instances such as `NoOp` and `Stdout`, or roll your own. `redis4cats` can derive an instance of `Log[F]` if there is an instance of `Logger[F]` in scope, just need to add the extra dependency `redis4cats-log4cats` and `import dev.profunktor.redis4cats.log4cats._`.
 
 Take a look at the [examples](https://github.com/profunktor/redis4cats/blob/master/modules/examples/src/main/scala/dev/profunktor/redis4cats/LoggerIOApp.scala) to find out more.
+
+#### Disable logging
+
+If you don't need logging at all, use the following import wherever a `Log` instance is required:
+
+```scala
+// Available for any `Applicative[F]`
+import dev.profunktor.redis4cats.effect.Log.NoOp._
+```
+
+If you need simple logging to STDOUT for quick debugging, you can use the following one:
+
+```scala
+// Available for any `Sync[F]`
+import dev.profunktor.redis4cats.effect.Log.Stdout._
+```
 
 ### Establishing connection
 

--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -11,7 +11,7 @@ position: 1
 import cats.effect._
 import cats.implicits._
 import dev.profunktor.redis4cats.Redis
-import dev.profunktor.redis4cats.effect.Log.noop // disable logging
+import dev.profunktor.redis4cats.effect.Log.Stdout._
 
 object QuickStart extends IOApp {
 


### PR DESCRIPTION
- Moving back to the `NoOp` instance for any `Applicative`, since I forgot people might use other effect types.
- Adding more documentation around logging.
- Introducing a `Log.Stdout` instance for any `Sync`.