### PR TITLE
Removing liftK from the commands algebra

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
@@ -31,6 +31,11 @@ trait RedisCommands[F[_], K, V]
     with TransactionalCommands[F, K]
     with PipelineCommands[F]
     with ScriptCommands[F, K, V]
-    with KeyCommands[F, K] {
-  def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V]
+    with KeyCommands[F, K]
+
+object RedisCommands {
+  implicit class LiftKOps[F[_], K, V](val cmd: RedisCommands[F, K, V]) extends AnyVal {
+    def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V] =
+      cmd.asInstanceOf[BaseRedis[F, K, V]].liftK[G]
+  }
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -350,7 +350,8 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
     blocker: Blocker
 ) extends RedisCommands[F, K, V]
     with RedisConversionOps {
-  override def liftK[G[_]: Concurrent: ContextShift]: BaseRedis[G, K, V] =
+
+  def liftK[G[_]: Concurrent: ContextShift]: RedisCommands[G, K, V] =
     new BaseRedis[G, K, V](conn.liftK[G], cluster, blocker)
 
   import dev.profunktor.redis4cats.JavaConversions._

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisLiftKDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisLiftKDemo.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats
+
+import cats.data.EitherT
+import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.effect.Log
+
+object RedisLiftKDemo extends LoggerIOApp {
+
+  import Demo._
+
+  def program(implicit log: Log[IO]): IO[Unit] = {
+    val usernameKey = "test"
+
+    val showResult: Option[String] => IO[Unit] =
+      _.fold(putStrLn(s"Not found key: $usernameKey"))(s => putStrLn(s))
+
+    val commandsApi: Resource[IO, RedisCommands[IO, String, String]] =
+      Redis[IO].utf8(redisURI)
+
+    commandsApi.use(
+      _.liftK[EitherT[IO, String, *]]
+        .get(usernameKey)
+        .semiflatMap(x => showResult(x))
+        .value
+        .void
+    )
+  }
+
+}


### PR DESCRIPTION
The `liftK` function is now an extension method to `RedisCommands[F, K, V]`.