### PR TITLE
Examples: Concurrent transactions with optimistic locking

### DIFF
--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/ConcurrentTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/ConcurrentTransactionsDemo.scala
@@ -56,9 +56,9 @@ object ConcurrentTransactionsDemo extends LoggerIOApp {
 
           val prog: IO[Unit] =
             RedisTransaction(cmd)
-              .exec(operations)
+              .filterExec(operations)
               .flatMap {
-                case _ ~: _ ~: res1 ~: _ ~: _ ~: res2 ~: HNil =>
+                case res1 ~: res2 ~: HNil =>
                   Log[IO].info(s"res1: $res1, res2: $res2")
               }
               .onError {

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/ConcurrentTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/ConcurrentTransactionsDemo.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats
+
+import cats.effect._
+import cats.implicits._
+import dev.profunktor.redis4cats.connection._
+import dev.profunktor.redis4cats.data.RedisCodec
+import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.hlist._
+import dev.profunktor.redis4cats.log4cats._
+import dev.profunktor.redis4cats.transactions._
+import java.util.concurrent.TimeoutException
+
+object ConcurrentTransactionsDemo extends LoggerIOApp {
+
+  import Demo._
+
+  def program: IO[Unit] = {
+    val key1 = "test1"
+    val key2 = "test2"
+
+    val showResult: String => Option[String] => IO[Unit] = key =>
+      _.fold(Log[IO].info(s"Key not found: $key"))(s => Log[IO].info(s"$key: $s"))
+
+    val mkClient: Resource[IO, RedisClient] =
+      Resource.liftF(RedisURI.make[IO](redisURI)).flatMap(RedisClient[IO](_))
+
+    val mkRedis: Resource[IO, RedisCommands[IO, String, String]] =
+      mkClient.flatMap(cli => Redis[IO].fromClient(cli, RedisCodec.Utf8))
+
+    def txProgram(v1: String, v2: String) =
+      mkRedis
+        .use { cmd =>
+          val getters =
+            cmd.get(key1).flatTap(showResult(key1)) *>
+                cmd.get(key2).flatTap(showResult(key2))
+
+          val operations =
+            cmd.set(key1, "sad") :: cmd.set(key2, "windows") :: cmd.get(key1) ::
+                cmd.set(key1, v1) :: cmd.set(key2, v2) :: cmd.get(key1) :: HNil
+
+          val prog: IO[Unit] =
+            RedisTransaction(cmd)
+              .exec(operations)
+              .flatMap {
+                case _ ~: _ ~: res1 ~: _ ~: _ ~: res2 ~: HNil =>
+                  Log[IO].info(s"res1: $res1, res2: $res2")
+              }
+              .onError {
+                case TransactionAborted =>
+                  Log[IO].error("[Error] - Transaction Aborted")
+                case TransactionDiscarded =>
+                  Log[IO].error("[Error] - Transaction Discarded")
+                case _: TimeoutException =>
+                  Log[IO].error("[Error] - Timeout")
+              }
+
+          val watching =
+            cmd.watch(key1, key2)
+
+          getters >> watching >> prog >> getters >> Log[IO].info("keep doing stuff...")
+        }
+
+    // Only the first transaction will be successful. The second one will be discarded.
+    //IO.race(txProgram("nix", "linux"), txProgram("foo", "bar")).void
+
+    def retriableTx: IO[Unit] =
+      txProgram("foo", "bar").handleErrorWith {
+        case TransactionDiscarded => retriableTx
+      }.uncancelable
+
+    // The first transaction will be successful but ultimately, the second transaction will retry and win
+    IO.race(txProgram("nix", "linux"), retriableTx).void
+  }
+
+}

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/JsonCodecDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/JsonCodecDemo.scala
@@ -20,7 +20,7 @@ import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.codecs.Codecs
 import dev.profunktor.redis4cats.codecs.splits.SplitEpi
 import dev.profunktor.redis4cats.data.RedisCodec
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import io.circe.generic.auto._
 import io.circe.parser.{ decode => jsonDecode }
 import io.circe.syntax._
@@ -37,7 +37,7 @@ object JsonCodecDemo extends LoggerIOApp {
     case object Unknown extends Event
   }
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val eventsKey = "events"
 
     val eventSplitEpi: SplitEpi[String, Event] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/LoggerIOApp.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/LoggerIOApp.scala
@@ -17,8 +17,6 @@
 package dev.profunktor.redis4cats
 
 import cats.effect.{ ExitCode, IO, IOApp }
-import dev.profunktor.redis4cats.effect.Log
-import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
@@ -29,12 +27,11 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
   * */
 trait LoggerIOApp extends IOApp {
 
-  def program(implicit log: Log[IO]): IO[Unit]
+  implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+  def program: IO[Unit]
 
   override def run(args: List[String]): IO[ExitCode] =
-    Slf4jLogger
-      .create[IO]
-      .flatMap { implicit logger: Logger[IO] => program }
-      .as(ExitCode.Success)
+    program.as(ExitCode.Success)
 
 }

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
@@ -19,10 +19,9 @@ package dev.profunktor.redis4cats
 import cats.effect.IO
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data.RedisChannel
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.pubsub.PubSub
 import fs2.{ Pipe, Stream }
-
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -36,7 +35,7 @@ object PubSubDemo extends LoggerIOApp {
   def sink(name: String): Pipe[IO, String, Unit] =
     _.evalMap(x => putStrLn(s"Subscriber: $name >> $x"))
 
-  def stream(implicit log: Log[IO]): Stream[IO, Unit] =
+  val stream: Stream[IO, Unit] =
     for {
       uri <- Stream.eval(RedisURI.make[IO](redisURI))
       client <- Stream.resource(RedisClient[IO](uri))
@@ -57,7 +56,7 @@ object PubSubDemo extends LoggerIOApp {
            ).parJoin(6).drain
     } yield rs
 
-  def program(implicit log: Log[IO]): IO[Unit] =
+  val program: IO[Unit] =
     stream.compile.drain
 
 }

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
@@ -19,10 +19,9 @@ package dev.profunktor.redis4cats
 import cats.effect.IO
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data.RedisChannel
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.pubsub.PubSub
 import fs2.Stream
-
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -32,7 +31,7 @@ object PublisherDemo extends LoggerIOApp {
 
   private val eventsChannel = RedisChannel("events")
 
-  def stream(implicit log: Log[IO]): Stream[IO, Unit] =
+  val stream: Stream[IO, Unit] =
     for {
       uri <- Stream.eval(RedisURI.make[IO](redisURI))
       client <- Stream.resource(RedisClient[IO](uri))
@@ -46,7 +45,7 @@ object PublisherDemo extends LoggerIOApp {
            ).parJoin(2).drain
     } yield rs
 
-  def program(implicit log: Log[IO]): IO[Unit] =
+  val program: IO[Unit] =
     stream.compile.drain
 
 }

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
@@ -18,13 +18,13 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.StringCommands
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
 object RedisClusterStringsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val usernameKey = "test"
 
     val showResult: Option[String] => IO[Unit] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
@@ -19,14 +19,14 @@ package dev.profunktor.redis4cats
 import cats.effect.{ IO, Resource }
 import cats.implicits._
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.transactions._
 
 object RedisClusterTransactionsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val key1 = "test1"
 
     val showResult: String => Option[String] => IO[Unit] = key =>

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
@@ -18,7 +18,7 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.GeoCommands
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.effects._
 import io.lettuce.core.GeoArgs
 
@@ -26,7 +26,7 @@ object RedisGeoDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val testKey = "location"
 
     val commandsApi: Resource[IO, GeoCommands[IO, String, String]] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
@@ -18,13 +18,13 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.HashCommands
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
 object RedisHashesDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val testKey   = "foo"
     val testField = "bar"
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
@@ -18,13 +18,13 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.{ KeyCommands, StringCommands }
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
 object RedisKeysDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val usernameKey = "test"
 
     val showResult: Option[String] => IO[Unit] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisLiftKDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisLiftKDemo.scala
@@ -18,13 +18,13 @@ package dev.profunktor.redis4cats
 
 import cats.data.EitherT
 import cats.effect.{ IO, Resource }
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
 object RedisLiftKDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val usernameKey = "test"
 
     val showResult: Option[String] => IO[Unit] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
@@ -18,13 +18,13 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.ListCommands
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
 object RedisListsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val testKey = "listos"
 
     val commandsApi: Resource[IO, ListCommands[IO, String, String]] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
@@ -19,13 +19,13 @@ package dev.profunktor.redis4cats
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data.ReadFrom
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
 object RedisMasterReplicaStringsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val usernameKey = "test"
 
     val showResult: Option[String] => IO[Unit] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
@@ -18,7 +18,7 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.hlist._
 import dev.profunktor.redis4cats.pipeline._
 import java.util.concurrent.TimeoutException
@@ -27,7 +27,7 @@ object RedisPipelineDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val key1 = "testp1"
     val key2 = "testp2"
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -18,14 +18,14 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.ScriptCommands
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.effects.ScriptOutputType
 
 object RedisScriptsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val commandsApi: Resource[IO, ScriptCommands[IO, String, String]] =
       Redis[IO].utf8(redisURI)
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
@@ -18,13 +18,13 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.SetCommands
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
 object RedisSetsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val testKey = "foos"
 
     val showResult: Set[String] => IO[Unit] = x => putStrLn(s"$testKey members: $x")

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
@@ -18,14 +18,14 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.SortedSetCommands
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.effects.{ Score, ScoreWithValue, ZRange }
 
 object RedisSortedSetsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val testKey = "zztop"
 
     val commandsApi: Resource[IO, SortedSetCommands[IO, String, Long]] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
@@ -18,13 +18,13 @@ package dev.profunktor.redis4cats
 
 import cats.effect.{ IO, Resource }
 import dev.profunktor.redis4cats.algebra.StringCommands
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 
 object RedisStringsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val usernameKey = "test"
 
     val showResult: Option[String] => IO[Unit] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala
@@ -18,8 +18,8 @@ package dev.profunktor.redis4cats
 
 import cats.effect._
 import cats.implicits._
-import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.hlist._
+import dev.profunktor.redis4cats.log4cats._
 import dev.profunktor.redis4cats.transactions._
 import java.util.concurrent.TimeoutException
 
@@ -27,7 +27,7 @@ object RedisTransactionsDemo extends LoggerIOApp {
 
   import Demo._
 
-  def program(implicit log: Log[IO]): IO[Unit] = {
+  val program: IO[Unit] = {
     val key1 = "test1"
     val key2 = "test2"
 

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/StreamingDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/StreamingDemo.scala
@@ -19,11 +19,10 @@ package dev.profunktor.redis4cats
 import cats.effect.IO
 import cats.syntax.parallel._
 import dev.profunktor.redis4cats.connection._
-import dev.profunktor.redis4cats.effect.Log
+import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.streams.RedisStream
 import dev.profunktor.redis4cats.streams.data.StreamingMessage
 import fs2.Stream
-
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -43,7 +42,7 @@ object StreamingDemo extends LoggerIOApp {
     }
   }
 
-  def stream(implicit log: Log[IO]): Stream[IO, Unit] =
+  val stream: Stream[IO, Unit] =
     for {
       uri <- Stream.eval(RedisURI.make[IO](redisURI))
       client <- Stream.resource(RedisClient[IO](uri))
@@ -56,7 +55,7 @@ object StreamingDemo extends LoggerIOApp {
            ).parJoin(2).drain
     } yield rs
 
-  def program(implicit log: Log[IO]): IO[Unit] =
+  val program: IO[Unit] =
     stream.compile.drain
 
 }

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -27,6 +27,7 @@ import cats.effect.{IO, Resource}
 import cats.implicits._
 import dev.profunktor.redis4cats._
 import dev.profunktor.redis4cats.data._
+import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.log4cats._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -55,7 +56,7 @@ val key1 = "test1"
 val key2 = "test2"
 
 val showResult: String => Option[String] => IO[Unit] = key =>
-  _.fold(putStrLn(s"Not found key: $key"))(s => putStrLn(s))
+  _.fold(Log[IO].info(s"Key not found: $key"))(s => Log[IO].info(s"$key: $s"))
 
 commandsApi.use { cmd => // RedisCommands[IO, String, String]
   val tx = RedisTransaction(cmd)
@@ -138,3 +139,75 @@ commandsApi.use { cmd =>
   getters *> failedTx.void *> getters.void
 }
 ```
+
+### Optimistic locking
+
+Redis provides an [optimistic locking using check-and-set](https://redis.io/topics/transactions#optimistic-locking-using-check-and-set) mechanism by using the `WATCH` command. Quoting the Redis documentation:
+
+> `WATCH`ed keys are monitored in order to detect changes against them. If at least one watched key is modified before the `EXEC` command, the whole transaction aborts, and `EXEC` returns a `Null` reply to notify that the transaction failed.
+
+This library translates the `Null` reply as a `TransactionDiscarded` error raised in the effect type. E.g.:
+
+```scala mdoc:silent
+val mkClient: Resource[IO, RedisClient] =
+  Resource.liftF(RedisURI.make[IO](redisURI)).flatMap(RedisClient[IO](_))
+
+val mkRedis: Resource[IO, RedisCommands[IO, String, String]] =
+  mkClient.flatMap(cli => Redis[IO].fromClient(cli, RedisCodec.Utf8))
+
+def txProgram(v1: String, v2: String) =
+  mkRedis
+    .use { cmd =>
+      val getters =
+        cmd.get(key1).flatTap(showResult(key1)) *>
+            cmd.get(key2).flatTap(showResult(key2))
+
+      val operations =
+        cmd.set(key1, "sad") :: cmd.set(key2, "windows") :: cmd.get(key1) ::
+            cmd.set(key1, v1) :: cmd.set(key2, v2) :: cmd.get(key1) :: HNil
+
+      val prog: IO[Unit] =
+        RedisTransaction(cmd)
+          .exec(operations)
+          .flatMap {
+            case _ ~: _ ~: res1 ~: _ ~: _ ~: res2 ~: HNil =>
+              Log[IO].info(s"res1: $res1, res2: $res2")
+          }
+          .onError {
+            case TransactionAborted =>
+              Log[IO].error("[Error] - Transaction Aborted")
+            case TransactionDiscarded =>
+              Log[IO].error("[Error] - Transaction Discarded")
+            case _: TimeoutException =>
+              Log[IO].error("[Error] - Timeout")
+          }
+
+      val watching =
+        cmd.watch(key1, key2)
+
+      getters >> watching >> prog >> getters >> Log[IO].info("keep doing stuff...")
+    }
+```
+
+Note that if we want to run transactions concurrently, we need to acquire a connection per transaction (`RedisCommands`), as `MULTI` can not be called concurrently within the same connection, reason why it is recommended to share the same `RedisClient`.
+
+Now before executing the transaction, we invoke `cmd.watch(key1, key2)`. Next, let's run two concurrent transactions:
+
+```scala mdoc:silent
+IO.race(txProgram("nix", "linux"), txProgram("foo", "bar")).void
+```
+
+In this case, only the first transaction will be successful. The second one will be discarded. However, we want to eventually succeed most of the time, in which case we can retry a transaction until it succeeds (optimistic locking).
+
+```scala mdoc:silent
+def retriableTx: IO[Unit] =
+  txProgram("foo", "bar").handleErrorWith {
+    case TransactionDiscarded => retriableTx
+  }.uncancelable
+
+IO.race(txProgram("nix", "linux"), retriableTx).void
+```
+
+The first transaction will be successful, but ultimately, the second transaction will retry and set the values "foo" and "bar".
+
+All these examples can be found under [RedisTransactionsDemo](https://github.com/profunktor/redis4cats/blob/master/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTransactionsDemo.scala) and [ConcurrentTransactionsDemo](https://github.com/profunktor/redis4cats/blob/master/modules/examples/src/main/scala/dev/profunktor/redis4cats/ConcurrentTransactionsDemo.scala), respectively.

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -80,11 +80,11 @@ commandsApi.use { cmd => // RedisCommands[IO, String, String]
       }
       .onError {
         case TransactionAborted =>
-          putStrLn("[Error] - Transaction Aborted")
+          Log[IO].error("[Error] - Transaction Aborted")
         case TransactionDiscarded =>
-          putStrLn("[Error] - Transaction Discarded")
+          Log[IO].error("[Error] - Transaction Discarded")
         case _: TimeoutException =>
-          putStrLn("[Error] - Timeout")
+          Log[IO].error("[Error] - Timeout")
       }
 
   getters >> prog >> getters.void
@@ -169,9 +169,9 @@ def txProgram(v1: String, v2: String) =
 
       val prog: IO[Unit] =
         RedisTransaction(cmd)
-          .exec(operations)
+          .filterExec(operations)
           .flatMap {
-            case _ ~: _ ~: res1 ~: _ ~: _ ~: res2 ~: HNil =>
+            case res1 ~: res2 ~: HNil =>
               Log[IO].info(s"res1: $res1, res2: $res2")
           }
           .onError {

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -26,6 +26,7 @@ Below you can find a first example of transactional commands.
 import cats.effect.{IO, Resource}
 import cats.implicits._
 import dev.profunktor.redis4cats._
+import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.effect.Log
 import dev.profunktor.redis4cats.log4cats._
@@ -150,7 +151,7 @@ This library translates the `Null` reply as a `TransactionDiscarded` error raise
 
 ```scala mdoc:silent
 val mkClient: Resource[IO, RedisClient] =
-  Resource.liftF(RedisURI.make[IO](redisURI)).flatMap(RedisClient[IO](_))
+  Resource.liftF(RedisURI.make[IO]("redis://localhost")).flatMap(RedisClient[IO](_))
 
 val mkRedis: Resource[IO, RedisCommands[IO, String, String]] =
   mkClient.flatMap(cli => Redis[IO].fromClient(cli, RedisCodec.Utf8))


### PR DESCRIPTION
It includes documentation for optimistic locking using the WATCH command (closes #73).