### PR TITLE
Debug-level logging for transactions and pipelining

### DIFF
--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/Log.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/Log.scala
@@ -38,8 +38,9 @@ import cats.effect.Sync
   * }}}
   * */
 trait Log[F[_]] {
-  def info(msg: => String): F[Unit]
+  def debug(msg: => String): F[Unit]
   def error(msg: => String): F[Unit]
+  def info(msg: => String): F[Unit]
 }
 
 object Log {
@@ -48,18 +49,21 @@ object Log {
   object NoOp {
     implicit def instance[F[_]: Applicative]: Log[F] =
       new Log[F] {
-        def info(msg: => String): F[Unit]  = F.unit
+        def debug(msg: => String): F[Unit] = F.unit
         def error(msg: => String): F[Unit] = F.unit
+        def info(msg: => String): F[Unit]  = F.unit
       }
   }
 
   object Stdout {
     implicit def instance[F[_]: Sync]: Log[F] =
       new Log[F] {
-        def info(msg: => String): F[Unit] =
+        def debug(msg: => String): F[Unit] =
           F.delay(Console.out.println(msg))
         def error(msg: => String): F[Unit] =
           F.delay(Console.err.println(msg))
+        def info(msg: => String): F[Unit] =
+          F.delay(Console.out.println(msg))
       }
   }
 

--- a/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
+++ b/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
@@ -23,8 +23,9 @@ object log4cats {
 
   implicit def log4CatsInstance[F[_]: Logger]: Log[F] =
     new Log[F] {
-      def info(msg: => String): F[Unit]  = F.info(msg)
+      def debug(msg: => String): F[Unit] = F.debug(msg)
       def error(msg: => String): F[Unit] = F.error(msg)
+      def info(msg: => String): F[Unit]  = F.info(msg)
     }
 
 }


### PR DESCRIPTION
The "started" and "completed" messages are not so relevant so I added a `debug` method to `Log`. It also contains a `UUID` to identify a transaction running concurrently as well.