### PR TITLE
Support for XADD MAXLEN ~ maxlen param

### DIFF
--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
@@ -20,7 +20,11 @@ import data._
 
 // format: off
 trait RawStreaming[F[_], K, V] {
-  def xAdd(key: K, body: Map[K, V]): F[MessageId]
+
+  /**
+    * @param approxMaxlen does XTRIM ~ maxlen if defined
+    */
+  def xAdd(key: K, body: Map[K, V], approxMaxlen: Option[Long] = None): F[MessageId]
   def xRead(streams: Set[StreamingOffset[K]]): F[List[StreamingMessageWithId[K, V]]]
 }
 


### PR DESCRIPTION
Hello,
there is an optional `MAXLEN` param for `XADD` command. I think this is actually what you usually want for production use. Neither `RawStreaming` nor `Streaming` currently supports it.

This pull request is just an illustration how it could look like for `RawStreaming`. I'm happy to adjust it to desired conventions and to work on `Streaming` api.

### Questions:

#### `RawStreaming`
1. I propose not to support exact length trim (without `~`). Cannot image usage for that. OK?
2. Which one of these or something else?
   - additional `xadd` method param (got my vote and is included in PR),
   - use `io.lettuce.core.XAddArgs` class,
   - make more *scalish* XAddArgs.


#### `Streaming`
Currently `StreamingMessage` is used both for input and output. I'd add new class `XAddStreamingMessage` but maybe there's smarter way to do it.