### PR TITLE
Simplify creation of RedisClient

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -123,11 +123,7 @@ object Redis {
       * instead, which allows you to re-use the same client.
       */
     def simple[K, V](uri: String, codec: RedisCodec[K, V]): Resource[F, RedisCommands[F, K, V]] =
-      for {
-        redisUri <- Resource.liftF(RedisURI.make[F](uri))
-        client <- RedisClient[F](redisUri)
-        redis <- this.fromClient(client, codec)
-      } yield redis
+      RedisClient[F].from(uri).flatMap(this.fromClient(_, codec))
 
     /**
       * Creates a [[RedisCommands]] for a single-node connection.
@@ -152,11 +148,7 @@ object Redis {
         opts: ClientOptions,
         codec: RedisCodec[K, V]
     ): Resource[F, RedisCommands[F, K, V]] =
-      for {
-        redisUri <- Resource.liftF(RedisURI.make[F](uri))
-        client <- RedisClient[F](redisUri, opts)
-        redis <- this.fromClient(client, codec)
-      } yield redis
+      RedisClient[F].withOptions(uri, opts).flatMap(this.fromClient(_, codec))
 
     /**
       * Creates a [[RedisCommands]] for a single-node connection to deal

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/ConcurrentTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/ConcurrentTransactionsDemo.scala
@@ -37,11 +37,8 @@ object ConcurrentTransactionsDemo extends LoggerIOApp {
     val showResult: String => Option[String] => IO[Unit] = key =>
       _.fold(Log[IO].info(s"Key not found: $key"))(s => Log[IO].info(s"$key: $s"))
 
-    val mkClient: Resource[IO, RedisClient] =
-      Resource.liftF(RedisURI.make[IO](redisURI)).flatMap(RedisClient[IO](_))
-
     val mkRedis: Resource[IO, RedisCommands[IO, String, String]] =
-      mkClient.flatMap(cli => Redis[IO].fromClient(cli, RedisCodec.Utf8))
+      RedisClient[IO].from(redisURI).flatMap(cli => Redis[IO].fromClient(cli, RedisCodec.Utf8))
 
     def txProgram(v1: String, v2: String) =
       mkRedis

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
@@ -37,8 +37,7 @@ object PubSubDemo extends LoggerIOApp {
 
   val stream: Stream[IO, Unit] =
     for {
-      uri <- Stream.eval(RedisURI.make[IO](redisURI))
-      client <- Stream.resource(RedisClient[IO](uri))
+      client <- Stream.resource(RedisClient[IO].from(redisURI))
       pubSub <- PubSub.mkPubSubConnection[IO, String, String](client, stringCodec)
       sub1 = pubSub.subscribe(eventsChannel)
       sub2 = pubSub.subscribe(gamesChannel)

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
@@ -33,8 +33,7 @@ object PublisherDemo extends LoggerIOApp {
 
   val stream: Stream[IO, Unit] =
     for {
-      uri <- Stream.eval(RedisURI.make[IO](redisURI))
-      client <- Stream.resource(RedisClient[IO](uri))
+      client <- Stream.resource(RedisClient[IO].from(redisURI))
       pubSub <- PubSub.mkPublisherConnection[IO, String, String](client, stringCodec)
       pub1 = pubSub.publish(eventsChannel)
       rs <- Stream(

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/StreamingDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/StreamingDemo.scala
@@ -44,8 +44,7 @@ object StreamingDemo extends LoggerIOApp {
 
   val stream: Stream[IO, Unit] =
     for {
-      uri <- Stream.eval(RedisURI.make[IO](redisURI))
-      client <- Stream.resource(RedisClient[IO](uri))
+      client <- Stream.resource(RedisClient[IO].from(redisURI))
       streaming <- RedisStream.mkStreamingConnection[IO, String, String](client, stringCodec)
       source   = streaming.read(Set(streamKey1, streamKey2))
       appender = streaming.append

--- a/site/docs/client.md
+++ b/site/docs/client.md
@@ -32,8 +32,7 @@ val stringCodec: RedisCodec[String, String] = RedisCodec.Utf8
 
 val commandsApi: Resource[IO, StringCommands[IO, String, String]] =
   for {
-    uri    <- Resource.liftF(RedisURI.make[IO]("redis://localhost"))
-    client <- RedisClient[IO](uri)
+    client <- RedisClient[IO].from("redis://localhost")
     redis  <- Redis[IO].fromClient(client, stringCodec)
   } yield redis
 ```
@@ -66,9 +65,8 @@ val mkOpts: IO[ClientOptions] =
 
 val api: Resource[IO, StringCommands[IO, String, String]] =
   for {
-    uri    <- Resource.liftF(RedisURI.make[IO]("redis://localhost"))
     opts   <- Resource.liftF(mkOpts)
-    client <- RedisClient[IO](uri, opts)
+    client <- RedisClient[IO].withOptions("redis://localhost", opts)
     redis  <- Redis[IO].fromClient(client, stringCodec)
   } yield redis
 ```
@@ -76,7 +74,6 @@ val api: Resource[IO, StringCommands[IO, String, String]] =
 Furthermore, you can pass a customized `Redis4CatsConfig` to configure behaviour which isn't covered by `io.lettuce.core.ClientOptions`:
 
 ```scala mdoc:silent
-import io.lettuce.core.{ ClientOptions, TimeoutOptions }
 import scala.concurrent.duration._
 
 val config = Redis4CatsConfig().withShutdown(ShutdownConfig(1.seconds, 5.seconds))
@@ -85,7 +82,7 @@ val configuredApi: Resource[IO, StringCommands[IO, String, String]] =
   for {
     uri    <- Resource.liftF(RedisURI.make[IO]("redis://localhost"))
     opts   <- Resource.liftF(mkOpts)
-    client <- RedisClient[IO](uri, opts, config)
+    client <- RedisClient[IO].custom(uri, opts, config)
     redis  <- Redis[IO].fromClient(client, stringCodec)
   } yield redis
 ```

--- a/site/docs/streams/pubsub.md
+++ b/site/docs/streams/pubsub.md
@@ -54,7 +54,7 @@ When using the `PubSub` interpreter the `publish` function will be defined as a 
 
 ```scala mdoc:silent
 import cats.effect.{ExitCode, IO, IOApp}
-import dev.profunktor.redis4cats.connection.{ RedisClient, RedisURI }
+import dev.profunktor.redis4cats.connection.RedisClient
 import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.pubsub.PubSub
 import dev.profunktor.redis4cats.log4cats._
@@ -78,8 +78,7 @@ object PubSubDemo extends IOApp {
 
   val program: Stream[IO, Unit] =
     for {
-      redisURI <- Stream.eval(RedisURI.make[IO]("redis://localhost"))
-      client <- Stream.resource(RedisClient[IO](redisURI))
+      client <- Stream.resource(RedisClient[IO].from("redis://localhost"))
       pubSub <- PubSub.mkPubSubConnection[IO, String, String](client, stringCodec)
       sub1   = pubSub.subscribe(eventsChannel)
       sub2   = pubSub.subscribe(gamesChannel)

--- a/site/docs/streams/streams.md
+++ b/site/docs/streams/streams.md
@@ -51,7 +51,7 @@ trait Streaming[F[_], K, V] {
 ```scala mdoc:silent
 import cats.effect.IO
 import cats.syntax.parallel._
-import dev.profunktor.redis4cats.connection.{ RedisClient, RedisURI }
+import dev.profunktor.redis4cats.connection.RedisClient
 import dev.profunktor.redis4cats.data._
 import dev.profunktor.redis4cats.log4cats._
 import dev.profunktor.redis4cats.streams.RedisStream
@@ -84,8 +84,7 @@ def randomMessage: Stream[IO, XAddMessage[String, String]] = Stream.eval {
 }
 
 for {
-  redisURI  <- Stream.eval(RedisURI.make[IO]("redis://localhost"))
-  client    <- Stream.resource(RedisClient[IO](redisURI))
+  client    <- Stream.resource(RedisClient[IO].from("redis://localhost"))
   streaming <- RedisStream.mkStreamingConnection[IO, String, String](client, stringCodec)
   source    = streaming.read(Set(streamKey1, streamKey2))
   appender  = streaming.append

--- a/site/docs/transactions.md
+++ b/site/docs/transactions.md
@@ -150,11 +150,10 @@ Redis provides a mechanism called [optimistic locking using check-and-set](https
 This library translates the `Null` reply as a `TransactionDiscarded` error raised in the effect type. E.g.:
 
 ```scala mdoc:silent
-val mkClient: Resource[IO, RedisClient] =
-  Resource.liftF(RedisURI.make[IO]("redis://localhost")).flatMap(RedisClient[IO](_))
-
 val mkRedis: Resource[IO, RedisCommands[IO, String, String]] =
-  mkClient.flatMap(cli => Redis[IO].fromClient(cli, RedisCodec.Utf8))
+  RedisClient[IO].from("redis://localhost").flatMap { cli =>
+    Redis[IO].fromClient(cli, RedisCodec.Utf8)
+  }
 
 def txProgram(v1: String, v2: String) =
   mkRedis


### PR DESCRIPTION
Instead of 

```scala
for {
  uri <- Resource.liftF(RedisURI.make[IO]("redis://localhost"))
  cli <- RedisClient[IO](uri)
} yield cli
```

We can now leave the creation of the URI to the client constructor

```scala
RedisClient[IO].from("redis://localhost")
```

There are other ways to create a client as well:

- `RedisClient[IO].withOptions(uri, opts)`
- `RedisClient[IO].custom(uri, opts, config)`