### PR TITLE
Return MessageId in Streaming#append

### DIFF
--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
@@ -69,8 +69,8 @@ class RedisStream[F[_]: Concurrent, K, V](rawStreaming: RedisRawStreaming[F, K, 
   private[streams] val offsetsByKey: List[XReadMessage[K, V]] => Map[K, Option[StreamingOffset[K]]] =
     list => list.groupBy(_.key).map { case (k, values) => k -> values.lastOption.map(nextOffset(k)) }
 
-  override def append: Stream[F, XAddMessage[K, V]] => Stream[F, Unit] =
-    _.evalMap(msg => rawStreaming.xAdd(msg.key, msg.body, msg.approxMaxlen).void)
+  override def append: Stream[F, XAddMessage[K, V]] => Stream[F, MessageId] =
+    _.evalMap(msg => rawStreaming.xAdd(msg.key, msg.body, msg.approxMaxlen))
 
   override def read(keys: Set[K], initialOffset: K => StreamingOffset[K]): Stream[F, XReadMessage[K, V]] = {
     val initial = keys.map(k => k -> initialOffset(k)).toMap

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
@@ -29,6 +29,6 @@ trait RawStreaming[F[_], K, V] {
 }
 
 trait Streaming[F[_], K, V] {
-  def append: F[XAddMessage[K, V]] => F[Unit]
+  def append: F[XAddMessage[K, V]] => F[MessageId]
   def read(keys: Set[K], initialOffset: K => StreamingOffset[K] = StreamingOffset.All[K]): F[XReadMessage[K, V]]
 }

--- a/site/docs/streams/streams.md
+++ b/site/docs/streams/streams.md
@@ -39,7 +39,7 @@ At the moment there's only two combinators:
 
 ```scala
 trait Streaming[F[_], K, V] {
-  def append: F[XAddMessage[K, V]] => F[Unit]
+  def append: F[XAddMessage[K, V]] => F[MessageId]
   def read(keys: Set[K], initialOffset: K => StreamingOffset[K] = StreamingOffset.All[K]): F[XReadMessage[K, V]]
 }
 ```


### PR DESCRIPTION
It's useful to catch the `MessageId` we get after appending, so that we can use it as an offset when reading.