### PR TITLE
Implement SCAN with arguments

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/keys.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/keys.scala
@@ -17,6 +17,7 @@
 package dev.profunktor.redis4cats.algebra
 
 import dev.profunktor.redis4cats.data.KeyScanCursor
+import dev.profunktor.redis4cats.effects.ScanArgs
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -29,4 +30,6 @@ trait KeyCommands[F[_], K] {
   def pttl(key: K): F[Option[FiniteDuration]]
   def scan: F[KeyScanCursor[K]]
   def scan(cursor: Long): F[KeyScanCursor[K]]
+  def scan(scanArgs: ScanArgs): F[KeyScanCursor[K]]
+  def scan(cursor: Long, scanArgs: ScanArgs): F[KeyScanCursor[K]]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -16,7 +16,7 @@
 
 package dev.profunktor.redis4cats
 
-import io.lettuce.core.{ GeoArgs, ScriptOutputType => JScriptOutputType }
+import io.lettuce.core.{ GeoArgs, ScriptOutputType => JScriptOutputType, ScanArgs => JScanArgs }
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -86,6 +86,20 @@ object effects {
       override private[redis4cats] val outputType                = JScriptOutputType.STATUS
       override private[redis4cats] def convert(in: String): Unit = ()
     }
+  }
+
+  case class ScanArgs(`match`: Option[String], count: Option[Long]) {
+    def underlying: JScanArgs = {
+      val u = new JScanArgs
+      `match`.foreach(u.`match`)
+      count.foreach(u.limit)
+      u
+    }
+  }
+  object ScanArgs {
+    def apply(`match`: String): ScanArgs              = ScanArgs(Some(`match`), None)
+    def apply(count: Long): ScanArgs                  = ScanArgs(None, Some(count))
+    def apply(`match`: String, count: Long): ScanArgs = ScanArgs(Some(`match`), Some(count))
   }
 
   sealed trait SetArg

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -397,15 +397,27 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
         case d                       => FiniteDuration(d, TimeUnit.MILLISECONDS).some
       }
 
-  def scan: F[KeyScanCursor[K]] =
+  override def scan: F[KeyScanCursor[K]] =
     async
       .flatMap(c => F.delay(c.scan()))
       .futureLift
       .map(KeyScanCursor[K])
 
-  def scan(cursor: Long): F[KeyScanCursor[K]] =
+  override def scan(cursor: Long): F[KeyScanCursor[K]] =
     async
       .flatMap(c => F.delay(c.scan(ScanCursor.of(cursor.toString))))
+      .futureLift
+      .map(KeyScanCursor[K])
+
+  override def scan(scanArgs: ScanArgs): F[KeyScanCursor[K]] =
+    async
+      .flatMap(c => F.delay(c.scan(scanArgs.underlying)))
+      .futureLift
+      .map(KeyScanCursor[K])
+
+  override def scan(cursor: Long, scanArgs: ScanArgs): F[KeyScanCursor[K]] =
+    async
+      .flatMap(c => F.delay(c.scan(ScanCursor.of(cursor.toString), scanArgs.underlying)))
       .futureLift
       .map(KeyScanCursor[K])
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
@@ -28,6 +28,8 @@ class RedisSpec extends Redis4CatsFunSuite(false) with TestScenarios {
 
   test("lists api")(withRedis(listsScenario))
 
+  test("keys api")(withRedis(keysScenario))
+
   test("sets api")(withRedis(setsScenario))
 
   test("sorted sets api")(withAbstractRedis(sortedSetsScenario)(RedisCodec(LongCodec)))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -147,6 +147,16 @@ trait TestScenarios {
       _ <- cmd.mSet(Map(key2 -> "some value 2"))
       exist3 <- cmd.exists(key1, key2)
       _ <- IO(assert(exist3))
+      scan0 <- cmd.scan
+      _ <- IO(assert(scan0.cursor == "0" && scan0.keys.sorted == List(key1, key2)))
+      scan1 <- cmd.scan(ScanArgs(1))
+      _ <- IO(assert(scan1.cursor != "0" && scan1.keys.length == 1))
+      scan2 <- cmd.scan(scan1.cursor.toLong, ScanArgs("key*"))
+      _ <- IO(
+            assert(
+              scan2.cursor == "0" && (scan1.keys ++ scan2.keys).sorted == List(key1, key2)
+            )
+          )
       exist4 <- cmd.exists(key1, key2, "_not_existing_key_")
       _ <- IO(assert(!exist4))
       _ <- cmd.del(key1)


### PR DESCRIPTION
Closes #331

In the end I decided to keep `cursor` separated. It closely resembles lettuce API but the implementation does not look too DRY.