### PR TITLE
Increment sequence number instead of timestamp to get the next offset

### DIFF
--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
@@ -76,7 +76,13 @@ class RedisStream[F[_]: Concurrent, K, V](rawStreaming: RedisRawStreaming[F, K, 
     extends Streaming[Stream[F, *], K, V] {
 
   private[streams] val nextOffset: K => XReadMessage[K, V] => StreamingOffset[K] =
-    key => msg => StreamingOffset.Custom(key, (msg.id.value.takeWhile(_ != '-').toLong + 1).toString)
+    key =>
+      msg =>
+        StreamingOffset.Custom(
+          key,
+          // increment the sequence number (second part of the ID after the dash)
+          s"${msg.id.value.takeWhile(_ != '-')}-${msg.id.value.dropWhile(_ != '-').drop(1).toLong + 1}"
+        )
 
   private[streams] val offsetsByKey: List[XReadMessage[K, V]] => Map[K, Option[StreamingOffset[K]]] =
     list => list.groupBy(_.key).map { case (k, values) => k -> values.lastOption.map(nextOffset(k)) }


### PR DESCRIPTION
[Docs](https://redis.io/topics/streams-intro):
> In order to continue the iteration with the next two items, I have to pick the last ID returned, that is 1519073279157-0 and add 1 to the sequence number part of the ID. Note that the sequence number is 64 bit so there is no need to check for overflows. The resulting ID, that is 1519073279157-1 in this case, can now be used as the new start argument for the next XRANGE call

Incrementing the timestamp will lose the other entries with the same timestamp.