### PR TITLE
sorted sets: zpopmin, zpopmax, bzpopmin, bzpopmax

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
@@ -20,7 +20,7 @@ import cats.data.NonEmptyList
 import dev.profunktor.redis4cats.effects.{ RangeLimit, ScoreWithValue, ZRange }
 import io.lettuce.core.{ ZAddArgs, ZStoreArgs }
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.Duration
 
 trait SortedSetCommands[F[_], K, V] extends SortedSetGetter[F, K, V] with SortedSetSetter[F, K, V]
 
@@ -51,8 +51,8 @@ trait SortedSetGetter[F[_], K, V] {
   def zScore(key: K, value: V): F[Option[Double]]
   def zPopMin(key: K, count: Long): F[List[ScoreWithValue[V]]]
   def zPopMax(key: K, count: Long): F[List[ScoreWithValue[V]]]
-  def bzPopMax(timeout: FiniteDuration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
-  def bzPopMin(timeout: FiniteDuration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
+  def bzPopMax(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
+  def bzPopMin(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
 }
 
 trait SortedSetSetter[F[_], K, V] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
@@ -16,8 +16,11 @@
 
 package dev.profunktor.redis4cats.algebra
 
+import cats.data.NonEmptyList
 import dev.profunktor.redis4cats.effects.{ RangeLimit, ScoreWithValue, ZRange }
 import io.lettuce.core.{ ZAddArgs, ZStoreArgs }
+
+import scala.concurrent.duration.FiniteDuration
 
 trait SortedSetCommands[F[_], K, V] extends SortedSetGetter[F, K, V] with SortedSetSetter[F, K, V]
 
@@ -46,6 +49,10 @@ trait SortedSetGetter[F[_], K, V] {
   def zRevRangeWithScores(key: K, start: Long, stop: Long): F[List[ScoreWithValue[V]]]
   def zRevRank(key: K, value: V): F[Option[Long]]
   def zScore(key: K, value: V): F[Option[Double]]
+  def zPopMin(key: K, count: Long): F[List[ScoreWithValue[V]]]
+  def zPopMax(key: K, count: Long): F[List[ScoreWithValue[V]]]
+  def bzPopMax(timeout: FiniteDuration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
+  def bzPopMin(timeout: FiniteDuration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
 }
 
 trait SortedSetSetter[F[_], K, V] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1188,15 +1188,15 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift, K, V](
       .futureLift
       .map(_.asScala.toList.map(_.asScoreWithValues))
 
-  override def bzPopMin(timeout: FiniteDuration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]] =
+  override def bzPopMin(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]] =
     async
-      .flatMap(c => F.delay(c.bzpopmin(timeout.toSeconds, keys.toList: _*)))
+      .flatMap(c => F.delay(c.bzpopmin(timeout.toSecondsOrZero, keys.toList: _*)))
       .futureLift
       .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScoreWithValues)))
 
-  override def bzPopMax(timeout: FiniteDuration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]] =
+  override def bzPopMax(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]] =
     async
-      .flatMap(c => F.delay(c.bzpopmax(timeout.toSeconds, keys.toList: _*)))
+      .flatMap(c => F.delay(c.bzpopmax(timeout.toSecondsOrZero, keys.toList: _*)))
       .futureLift
       .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScoreWithValues)))
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -18,6 +18,7 @@ package dev.profunktor.redis4cats
 
 import java.time.Instant
 
+import cats.data.NonEmptyList
 import cats.effect._
 import cats.implicits._
 import dev.profunktor.redis4cats.effect.Log.NoOp._
@@ -26,6 +27,7 @@ import dev.profunktor.redis4cats.hlist._
 import dev.profunktor.redis4cats.pipeline.RedisPipeline
 import dev.profunktor.redis4cats.transactions.RedisTransaction
 import io.lettuce.core.GeoArgs
+
 import scala.concurrent.duration._
 
 trait TestScenarios {
@@ -115,11 +117,34 @@ trait TestScenarios {
   }
 
   def sortedSetsScenario(cmd: RedisCommands[IO, String, Long]): IO[Unit] = {
-    val testKey = "zztop"
+    val testKey         = "zztop"
+    val scoreWithValue1 = ScoreWithValue(Score(1), 1L)
+    val scoreWithValue2 = ScoreWithValue(Score(3), 2L)
+    val timeout         = 1.second
     for {
+      minPop1 <- cmd.zPopMin(testKey, 1)
+      _ <- IO(assert(minPop1.isEmpty))
+      maxPop1 <- cmd.zPopMax(testKey, 1)
+      _ <- IO(assert(maxPop1.isEmpty))
+      minBPop1 <- cmd.bzPopMin(timeout, NonEmptyList.one(testKey))
+      _ <- IO(assert(minBPop1.isEmpty))
+      maxBPop1 <- cmd.bzPopMax(timeout, NonEmptyList.one(testKey))
+      _ <- IO(assert(maxBPop1.isEmpty))
       t <- cmd.zRevRangeByScore(testKey, ZRange(0, 2), limit = None)
       _ <- IO(assert(t.isEmpty))
-      _ <- cmd.zAdd(testKey, args = None, ScoreWithValue(Score(1), 1), ScoreWithValue(Score(3), 2))
+      _ <- cmd.zAdd(testKey, args = None, scoreWithValue1, scoreWithValue2)
+      minPop2 <- cmd.zPopMin(testKey, 1)
+      _ <- IO(assert(minPop2 == List(scoreWithValue1)))
+      maxPop2 <- cmd.zPopMax(testKey, 1)
+      _ <- IO(assert(maxPop2 == List(scoreWithValue2)))
+      _ <- cmd.zCard(testKey).map(card => assert(card.contains(0)))
+      _ <- cmd.zAdd(testKey, args = None, scoreWithValue1, scoreWithValue2)
+      minBPop2 <- cmd.bzPopMin(timeout, NonEmptyList.one(testKey))
+      _ <- IO(assert(minBPop2.contains((testKey, scoreWithValue1))))
+      maxBPop2 <- cmd.bzPopMax(timeout, NonEmptyList.one(testKey))
+      _ <- IO(assert(maxBPop2.contains((testKey, scoreWithValue2))))
+      _ <- cmd.zCard(testKey).map(card => assert(card.contains(0)))
+      _ <- cmd.zAdd(testKey, args = None, scoreWithValue1, scoreWithValue2)
       x <- cmd.zRevRangeByScore(testKey, ZRange(0, 2), limit = None)
       _ <- IO(assert(x == List(1)))
       y <- cmd.zCard(testKey)

--- a/site/docs/effects/index.md
+++ b/site/docs/effects/index.md
@@ -16,6 +16,6 @@ The API that operates at the effect level `F[_]` on top of `cats-effect`.
 - **[Scripting API](./scripting.html)**
 - **[Server API](./server.html)**
 - **[Sets API](./sets.html)**
-- **[Sorted SetsAPI](./sortedsets.html)**
+- **[Sorted Sets API](./sortedsets.html)**
 - **[Strings API](./strings.html)**
 


### PR DESCRIPTION
Implemented the following commands for sorted sets:
- [ZPOPMIN](https://redis.io/commands/zpopmin)
- [ZPOPMAX](https://redis.io/commands/zpopmax)
- [BZPOPMIN](https://redis.io/commands/bzpopmin)
- [BZPOPMAX](https://redis.io/commands/bzpopmax)