### PR TITLE
Fix ZCOUNT signature

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
@@ -26,7 +26,7 @@ trait SortedSetCommands[F[_], K, V] extends SortedSetGetter[F, K, V] with Sorted
 
 trait SortedSetGetter[F[_], K, V] {
   def zCard(key: K): F[Option[Long]]
-  def zCount(key: K, range: ZRange[V])(implicit ev: Numeric[V]): F[Option[Long]]
+  def zCount[T: Numeric](key: K, range: ZRange[T]): F[Option[Long]]
   def zLexCount(key: K, range: ZRange[V]): F[Option[Long]]
   def zRange(key: K, start: Long, stop: Long): F[List[V]]
   def zRangeByLex(key: K, range: ZRange[V], limit: Option[RangeLimit]): F[List[V]]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1095,7 +1095,7 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: Log, K, V](
       .futureLift
       .map(x => Option(Long.unbox(x)))
 
-  override def zCount(key: K, range: ZRange[V])(implicit ev: Numeric[V]): F[Option[Long]] =
+  override def zCount[T: Numeric](key: K, range: ZRange[T]): F[Option[Long]] =
     async
       .flatMap(c => F.delay(c.zcount(key, range.asJavaRange)))
       .futureLift


### PR DESCRIPTION
The current ZCOUNT signatures forces the `ZRange` to have the type of `V` but the [docs](https://redis.io/commands/zcount) say you need to pass a score, which is independent from the value type `V`. As per the docs, the semantics should be the same as `ZRANGEBYSCORE` which has signature `zRangeByScore[T: Numeric](key: K, range: ZRange[T], ...)`.