### PR TITLE
Improve ttl implementations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import com.scalapenos.sbt.prompt._
 import Dependencies._
 import microsites.ExtraMdFileConfig
 
-ThisBuild / name := """redis4cats"""
 ThisBuild / crossScalaVersions := Seq("2.12.10", "2.13.2")
 
 // publishing

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -408,7 +408,7 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: Log, K, V](
         case d    => FiniteDuration(d, TimeUnit.SECONDS).some
       }
 
-  private def toFiniteDuration(duration: Long): Option[FiniteDuration] =
+  private def toFiniteDuration(duration: java.lang.Long): Option[FiniteDuration] =
     duration match {
       case d if d < 0 => none[FiniteDuration]
       case d          => FiniteDuration(d, TimeUnit.SECONDS).some

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -408,23 +408,23 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: Log, K, V](
         case d    => FiniteDuration(d, TimeUnit.SECONDS).some
       }
 
+  private def toFiniteDuration(duration: Long): Option[FiniteDuration] =
+    duration match {
+      case d if d < 0 => none[FiniteDuration]
+      case d          => FiniteDuration(d, TimeUnit.SECONDS).some
+    }
+
   override def ttl(key: K): F[Option[FiniteDuration]] =
     async
       .flatMap(c => F.delay(c.ttl(key)))
       .futureLift
-      .map {
-        case d if d < 0 => none[FiniteDuration]
-        case d          => FiniteDuration(d, TimeUnit.SECONDS).some
-      }
+      .map(toFiniteDuration)
 
   override def pttl(key: K): F[Option[FiniteDuration]] =
     async
       .flatMap(c => F.delay(c.pttl(key)))
       .futureLift
-      .map {
-        case d if d < 0 => none[FiniteDuration]
-        case d          => FiniteDuration(d, TimeUnit.MILLISECONDS).some
-      }
+      .map(toFiniteDuration)
 
   override def scan: F[KeyScanCursor[K]] =
     async

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -360,10 +360,10 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: Log, K, V](
     if (cluster) conn.clusterSync else conn.sync.widen
 
   /******************************* Keys API *************************************/
-  def del(key: K*): F[Long] =
+  override def del(key: K*): F[Long] =
     async.flatMap(c => F.delay(c.del(key: _*))).futureLift.map(x => Long.box(x))
 
-  def exists(key: K*): F[Boolean] =
+  override def exists(key: K*): F[Boolean] =
     async
       .flatMap(c => F.delay(c.exists(key: _*)))
       .futureLift
@@ -375,7 +375,7 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: Log, K, V](
     *
     * As expected by Redis' PEXPIRE and EXPIRE commands, respectively.
     */
-  def expire(key: K, expiresIn: FiniteDuration): F[Boolean] =
+  override def expire(key: K, expiresIn: FiniteDuration): F[Boolean] =
     async
       .flatMap { c =>
         expiresIn.unit match {
@@ -393,13 +393,13 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: Log, K, V](
     *
     * It calls Redis' PEXPIREAT under the hood, which has milliseconds precision.
     */
-  def expireAt(key: K, at: Instant): F[Boolean] =
+  override def expireAt(key: K, at: Instant): F[Boolean] =
     async
       .flatMap(c => F.delay(c.pexpireat(key, at.toEpochMilli())))
       .futureLift
       .map(x => Boolean.box(x))
 
-  def objectIdletime(key: K): F[Option[FiniteDuration]] =
+  override def objectIdletime(key: K): F[Option[FiniteDuration]] =
     async
       .flatMap(c => F.delay(c.objectIdletime(key)))
       .futureLift
@@ -408,22 +408,22 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: Log, K, V](
         case d    => FiniteDuration(d, TimeUnit.SECONDS).some
       }
 
-  def ttl(key: K): F[Option[FiniteDuration]] =
+  override def ttl(key: K): F[Option[FiniteDuration]] =
     async
       .flatMap(c => F.delay(c.ttl(key)))
       .futureLift
       .map {
-        case d if d == -2 || d == -1 => none[FiniteDuration]
-        case d                       => FiniteDuration(d, TimeUnit.SECONDS).some
+        case d if d < 0 => none[FiniteDuration]
+        case d          => FiniteDuration(d, TimeUnit.SECONDS).some
       }
 
-  def pttl(key: K): F[Option[FiniteDuration]] =
+  override def pttl(key: K): F[Option[FiniteDuration]] =
     async
       .flatMap(c => F.delay(c.pttl(key)))
       .futureLift
       .map {
-        case d if d == -2 || d == -1 => none[FiniteDuration]
-        case d                       => FiniteDuration(d, TimeUnit.MILLISECONDS).some
+        case d if d < 0 => none[FiniteDuration]
+        case d          => FiniteDuration(d, TimeUnit.MILLISECONDS).some
       }
 
   override def scan: F[KeyScanCursor[K]] =


### PR DESCRIPTION
The [documentation](https://redis.io/commands/ttl) says the response is

> Integer reply: TTL in seconds, or a negative value in order to signal an error (see the description above).

I don't know why we were only checking `-2` and `-1`.