### PR TITLE
Asynchronous XREAD to prevent constant polling of redis streams

### DIFF
--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2RawStreaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2RawStreaming.scala
@@ -23,9 +23,8 @@ import dev.profunktor.redis4cats.effect.JRFuture
 import dev.profunktor.redis4cats.streams.data._
 import io.lettuce.core.XReadArgs.StreamOffset
 import io.lettuce.core.api.StatefulRedisConnection
-
 import dev.profunktor.redis4cats.JavaConversions._
-import io.lettuce.core.XAddArgs
+import io.lettuce.core.{XAddArgs, XReadArgs}
 
 private[streams] class RedisRawStreaming[F[_]: Concurrent: ContextShift, K, V](
     val client: StatefulRedisConnection[K, V],
@@ -42,7 +41,7 @@ private[streams] class RedisRawStreaming[F[_]: Concurrent: ContextShift, K, V](
   override def xRead(streams: Set[StreamingOffset[K]]): F[List[XReadMessage[K, V]]] = {
     val offsets = streams.map(s => StreamOffset.from(s.key, s.offset)).toSeq
     JRFuture {
-      F.delay(client.async().xread(offsets: _*))
+      F.delay(client.async().xread(XReadArgs.Builder.block(0), offsets: _*))
     }(blocker).map { list =>
       list.asScala.toList.map { msg =>
         XReadMessage[K, V](MessageId(msg.getId), msg.getStream, msg.getBody.asScala.toMap)

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2RawStreaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2RawStreaming.scala
@@ -24,7 +24,7 @@ import dev.profunktor.redis4cats.streams.data._
 import io.lettuce.core.XReadArgs.StreamOffset
 import io.lettuce.core.api.StatefulRedisConnection
 import dev.profunktor.redis4cats.JavaConversions._
-import io.lettuce.core.{XAddArgs, XReadArgs}
+import io.lettuce.core.{ XAddArgs, XReadArgs }
 
 private[streams] class RedisRawStreaming[F[_]: Concurrent: ContextShift, K, V](
     val client: StatefulRedisConnection[K, V],

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
@@ -21,8 +21,9 @@ import cats.syntax.all._
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.effect.Log.NoOp._
+import dev.profunktor.redis4cats.streams.{RedisStream, Streaming}
 
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
 
 abstract class Redis4CatsFunSuite(isCluster: Boolean) extends IOSuite {
@@ -45,6 +46,14 @@ abstract class Redis4CatsFunSuite(isCluster: Boolean) extends IOSuite {
 
   def withRedis[A](f: RedisCommands[IO, String, String] => IO[A]): Future[Unit] =
     withAbstractRedis[A, String, String](f)(stringCodec)
+
+  def withRedisStream[A](f: Streaming[fs2.Stream[IO, *], String, String] => IO[A]): Future[Unit] = {
+    (for {
+      client <- fs2.Stream.resource(RedisClient[IO].from("redis://localhost"))
+      streams <- RedisStream.mkStreamingConnection[IO, String, String](client, stringCodec)
+      results <- fs2.Stream.eval(f(streams))
+    } yield results).compile.drain.void.unsafeToFuture()
+  }
 
   private def flushAll(): Future[Unit] =
     if (isCluster) withRedisCluster(_.flushAll)

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats
+
+import dev.profunktor.redis4cats.streams.data.XAddMessage
+
+import scala.concurrent.duration.DurationInt
+
+class RedisStreamSpec extends Redis4CatsFunSuite(false) {
+
+  test("append/read to/from a stream") {
+    withRedisStream[Unit] { stream =>
+      val read = stream.read(Set("test-stream"))
+      val write = stream.append(fs2.Stream(XAddMessage("test-stream", Map("hello" -> "world"))))
+
+      read
+        .concurrently(write)
+        .take(1)
+        .interruptAfter(3.seconds)
+        .compile
+        .lastOrError
+        .map { read =>
+          assertEquals(read.key, "test-stream")
+          assertEquals(read.body, Map("hello" -> "world"))
+        }
+    }
+  }
+
+}


### PR DESCRIPTION
This is about: https://github.com/profunktor/redis4cats/issues/446