### PR TITLE
Support for subscribing to multiple pubsub channels

### DIFF
--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSub.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSub.scala
@@ -63,7 +63,8 @@ object PubSub {
         state <- Resource.liftF(Ref.of[F, Map[K, Topic[F, Option[V]]]](Map.empty))
         sConn <- Resource.make(acquire)(release)
         pConn <- Resource.make(acquire)(release)
-      } yield new LivePubSubCommands[F, K, V](state, sConn, pConn, blocker)
+        sub <- Subscriber.resource(state, sConn, blocker)
+      } yield new LivePubSubCommands[F, K, V](pConn, blocker, sub)
     }
 
   /**
@@ -94,7 +95,8 @@ object PubSub {
       for {
         state <- Resource.liftF(Ref.of[F, Map[K, Topic[F, Option[V]]]](Map.empty))
         conn <- Resource.make(acquire)(release)
-      } yield new Subscriber(state, conn, blocker)
+        subscriber <- Subscriber.resource(state, conn, blocker)
+      } yield subscriber
     }
 
 }

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSubCommands.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSubCommands.scala
@@ -31,8 +31,8 @@ trait PublishCommands[F[_], K, V] extends PubSubStats[F, K] {
 }
 
 trait SubscribeCommands[F[_], K, V] {
-  def subscribe(channel: RedisChannel[K]): F[V]
-  def unsubscribe(channel: RedisChannel[K]): F[Unit]
+  def subscribe(channels: RedisChannel[K]*): F[V]
+  def unsubscribe(channels: RedisChannel[K]*): F[Unit]
 }
 
 trait PubSubCommands[F[_], K, V] extends PublishCommands[F, K, V] with SubscribeCommands[F, K, V]

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/package.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/package.scala
@@ -22,5 +22,5 @@ import fs2.concurrent.Topic
 package object internals {
   private[pubsub] type PubSubState[F[_], K, V] = Map[K, Topic[F, Option[V]]]
   private[pubsub] type GetOrCreateTopicListener[F[_], K, V] =
-    Seq[RedisChannel[K]] => PubSubState[F, K, V] => F[Topic[F, Option[V]]]
+    Seq[RedisChannel[K]] => F[Topic[F, Option[V]]]
 }

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/package.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/package.scala
@@ -22,5 +22,5 @@ import fs2.concurrent.Topic
 package object internals {
   private[pubsub] type PubSubState[F[_], K, V] = Map[K, Topic[F, Option[V]]]
   private[pubsub] type GetOrCreateTopicListener[F[_], K, V] =
-    RedisChannel[K] => PubSubState[F, K, V] => F[Topic[F, Option[V]]]
+    Seq[RedisChannel[K]] => PubSubState[F, K, V] => F[Topic[F, Option[V]]]
 }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisPubSubSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisPubSubSpec.scala
@@ -46,7 +46,7 @@ class RedisPubSubSpec extends Redis4CatsFunSuite(false) {
         .Stream("one")
         .through(redis.publish(channelFour))
         .concurrently(fs2.Stream("two", "three").through(redis.publish(channelFive)))
-        .delayBy(100.millis)
+        .delayBy(101.millis)
         .compile
         .drain
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisPubSubSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisPubSubSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats
+
+import cats.implicits.catsSyntaxTuple3Parallel
+import dev.profunktor.redis4cats.data.RedisChannel
+
+import scala.concurrent.duration._
+
+class RedisPubSubSpec extends Redis4CatsFunSuite(false) {
+  private val channelFour = RedisChannel("channelFour")
+  private val channelFive = RedisChannel("channelFive")
+
+  test("subscribe to multiple channels") {
+    withRedisPubSub { redis =>
+      redis
+        .subscribe(channelFour, channelFive)
+        .take(3)
+        .concurrently(fs2.Stream("one").through(redis.publish(channelFour)).delayBy(100.millis))
+        .concurrently(fs2.Stream("two", "three").through(redis.publish(channelFive)).delayBy(100.millis))
+        .compile
+        .toVector
+        .map(a => assertEquals(a.sorted, Vector("one", "two", "three").sorted))
+    }
+  }
+
+  test("multiple subscriptions should get their own messages") {
+    withRedisPubSub { redis =>
+      val ch4 = redis.subscribe(channelFour).take(1).compile.toVector
+      val ch5 = redis.subscribe(channelFive).take(2).compile.toVector
+      val publisher = fs2
+        .Stream("one")
+        .through(redis.publish(channelFour))
+        .concurrently(fs2.Stream("two", "three").through(redis.publish(channelFive)))
+        .delayBy(100.millis)
+        .compile
+        .drain
+
+      for {
+        (rc4, rc5) <- (ch4, ch5, publisher).parMapN((a, b, _) => a -> b)
+      } yield {
+        assertEquals(rc4, Vector("one"))
+        assertEquals(rc5, Vector("two", "three"))
+      }
+    }
+  }
+
+  test("messages are not delivered after unsubscribing from a channel") {
+    withRedisPubSub { redis =>
+      redis
+        .subscribe(channelFour)
+        .groupWithin(100, 500.millis)
+        .take(1)
+        .concurrently(fs2.Stream("one", "two", "three").through(redis.publish(channelFour)).metered(100.millis))
+        .concurrently(redis.unsubscribe(channelFour).delayBy(300.millis))
+        .compile
+        .toVector
+        .map(a => assertEquals(a.flatMap(_.toVector).sorted, Vector("one", "two").sorted))
+    }
+  }
+
+}

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisPubSubSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisPubSubSpec.scala
@@ -72,5 +72,4 @@ class RedisPubSubSpec extends Redis4CatsFunSuite(false) {
         .map(a => assertEquals(a.flatMap(_.toVector).sorted, Vector("one", "two").sorted))
     }
   }
-
 }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisPubSubSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisPubSubSpec.scala
@@ -44,8 +44,9 @@ class RedisPubSubSpec extends Redis4CatsFunSuite(false) {
       val ch5 = redis.subscribe(channelFive).take(2).compile.toVector
       val publisher = fs2
         .Stream("one")
+        .repeatN(3)
         .through(redis.publish(channelFour))
-        .concurrently(fs2.Stream("two", "three").through(redis.publish(channelFive)))
+        .concurrently(fs2.Stream("two", "three").repeatN(3).through(redis.publish(channelFive)))
         .delayBy(101.millis)
         .compile
         .drain


### PR DESCRIPTION
This is more of a feature request, rather than a production quality code.
It does however pass the tests and fulfills my needs.

I need to subscribe to multiple pubsub channels in one redis connection.
Lettuce supports is, just it's not being surfaced by redis4cats.
The thing that I don't understand, is the filtering done in `PubSubInternals`:
`if (ch == channel.underlying) `
I've removed it, as it filters out messages coming from the additional channels.