### PR TITLE
Improving zRemRangeByScore method interface

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
@@ -63,6 +63,6 @@ trait SortedSetSetter[F[_], K, V] {
   def zRem(key: K, values: V*): F[Long]
   def zRemRangeByLex(key: K, range: ZRange[V]): F[Long]
   def zRemRangeByRank(key: K, start: Long, stop: Long): F[Long]
-  def zRemRangeByScore(key: K, range: ZRange[V])(implicit ev: Numeric[V]): F[Long]
+  def zRemRangeByScore[T: Numeric](key: K, range: ZRange[T]): F[Long]
   def zUnionStore(destination: K, args: Option[ZStoreArgs], keys: K*): F[Long]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1085,7 +1085,7 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: Log, K, V](
   override def zRemRangeByRank(key: K, start: Long, stop: Long): F[Long] =
     async.flatMap(c => blocker.delay(c.zremrangebyrank(key, start, stop))).futureLift.map(x => Long.box(x))
 
-  override def zRemRangeByScore(key: K, range: ZRange[V])(implicit ev: Numeric[V]): F[Long] =
+  override def zRemRangeByScore[T: Numeric](key: K, range: ZRange[T]): F[Long] =
     async.flatMap(c => blocker.delay(c.zremrangebyscore(key, range.asJavaRange))).futureLift.map(x => Long.box(x))
 
   override def zUnionStore(destination: K, args: Option[ZStoreArgs], keys: K*): F[Long] = {


### PR DESCRIPTION
Hi! I've found that range parameter in zRemRangeByScore depends on stored value type and must be numeric. But it must be numeric no matter what type of stored value is.
So I've fixed that