### PR TITLE
Fix log4cats adapter

### DIFF
--- a/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
+++ b/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
@@ -23,9 +23,9 @@ object log4cats {
 
   implicit def log4CatsInstance[F[_]: Logger]: Log[F] =
     new Log[F] {
-      def debug(msg: => String): F[Unit] = Log[F].debug(msg)
-      def error(msg: => String): F[Unit] = Log[F].error(msg)
-      def info(msg: => String): F[Unit]  = Log[F].info(msg)
+      def debug(msg: => String): F[Unit] = Logger[F].debug(msg)
+      def error(msg: => String): F[Unit] = Logger[F].error(msg)
+      def info(msg: => String): F[Unit]  = Logger[F].info(msg)
     }
 
 }


### PR DESCRIPTION
There is an issue introduced via #485. The wrong summoner causes recursion.