### PR TITLE
Fix/xread offset

### DIFF
--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2RawStreaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2RawStreaming.scala
@@ -24,7 +24,10 @@ import dev.profunktor.redis4cats.streams.data._
 import io.lettuce.core.XReadArgs.StreamOffset
 import io.lettuce.core.api.StatefulRedisConnection
 import dev.profunktor.redis4cats.JavaConversions._
+import dev.profunktor.redis4cats.streams.data.StreamingOffset.{ All, Custom, Latest }
 import io.lettuce.core.{ XAddArgs, XReadArgs }
+
+import scala.concurrent.duration.Duration
 
 private[streams] class RedisRawStreaming[F[_]: Concurrent: ContextShift: RedisExecutor, K, V](
     val client: StatefulRedisConnection[K, V]
@@ -37,8 +40,18 @@ private[streams] class RedisRawStreaming[F[_]: Concurrent: ContextShift: RedisEx
       Sync[F].delay(client.async().xadd(key, args.orNull, body.asJava))
     }.map(MessageId.apply)
 
-  override def xRead(streams: Set[StreamingOffset[K]]): F[List[XReadMessage[K, V]]] = {
-    val offsets = streams.map(s => StreamOffset.from(s.key, s.offset)).toSeq
+  override def xRead(
+      streams: Set[StreamingOffset[K]],
+      block: Duration = Duration.Zero,
+      count: Option[Int] = None
+  ): F[List[XReadMessage[K, V]]] = {
+
+    val offsets = streams.map {
+      case All(key)            => StreamOffset.from(key, "0")
+      case Latest(key)         => StreamOffset.latest(key)
+      case Custom(key, offset) => StreamOffset.from(key, offset)
+    }.toSeq
+
     JRFuture {
       Sync[F].delay(client.async().xread(XReadArgs.Builder.block(0), offsets: _*))
     }.map { list =>

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
@@ -88,8 +88,8 @@ class RedisStream[F[_]: Concurrent, K, V](rawStreaming: RedisRawStreaming[F, K, 
   override def read(
       keys: Set[K],
       initialOffset: K => StreamingOffset[K],
-      block: Duration = Duration.Zero,
-      count: Option[Int] = None
+      block: Option[Duration] = Some(Duration.Zero),
+      count: Option[Long] = None
   ): Stream[F, XReadMessage[K, V]] = {
     val initial = keys.map(k => k -> initialOffset(k)).toMap
     Stream.eval(Ref.of[F, Map[K, StreamingOffset[K]]](initial)).flatMap { ref =>

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
@@ -18,6 +18,8 @@ package dev.profunktor.redis4cats.streams
 
 import data._
 
+import scala.concurrent.duration.Duration
+
 // format: off
 trait RawStreaming[F[_], K, V] {
 
@@ -25,10 +27,19 @@ trait RawStreaming[F[_], K, V] {
     * @param approxMaxlen does XTRIM ~ maxlen if defined
     */
   def xAdd(key: K, body: Map[K, V], approxMaxlen: Option[Long] = None): F[MessageId]
-  def xRead(streams: Set[StreamingOffset[K]]): F[List[XReadMessage[K, V]]]
+  def xRead(
+    streams: Set[StreamingOffset[K]],
+    block: Duration = Duration.Zero,
+    count: Option[Int] = None,
+  ): F[List[XReadMessage[K, V]]]
 }
 
 trait Streaming[F[_], K, V] {
   def append: F[XAddMessage[K, V]] => F[MessageId]
-  def read(keys: Set[K], initialOffset: K => StreamingOffset[K] = StreamingOffset.All[K]): F[XReadMessage[K, V]]
+  def read(
+    keys: Set[K],
+    initialOffset: K => StreamingOffset[K] = StreamingOffset.All[K],
+    block: Duration = Duration.Zero,
+    count: Option[Int] = None,
+  ): F[XReadMessage[K, V]]
 }

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
@@ -29,8 +29,8 @@ trait RawStreaming[F[_], K, V] {
   def xAdd(key: K, body: Map[K, V], approxMaxlen: Option[Long] = None): F[MessageId]
   def xRead(
     streams: Set[StreamingOffset[K]],
-    block: Duration = Duration.Zero,
-    count: Option[Int] = None,
+    block: Option[Duration] = Some(Duration.Zero),
+    count: Option[Long] = None
   ): F[List[XReadMessage[K, V]]]
 }
 
@@ -39,7 +39,7 @@ trait Streaming[F[_], K, V] {
   def read(
     keys: Set[K],
     initialOffset: K => StreamingOffset[K] = StreamingOffset.All[K],
-    block: Duration = Duration.Zero,
-    count: Option[Int] = None,
+    block: Option[Duration] = Some(Duration.Zero),
+    count: Option[Long] = None
   ): F[XReadMessage[K, V]]
 }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
@@ -22,8 +22,7 @@ import scala.concurrent.duration.DurationInt
 
 class RedisStreamSpec extends Redis4CatsFunSuite(false) {
 
-  //FIXME: https://github.com/profunktor/redis4cats/issues/460
-  test("append/read to/from a stream".ignore) {
+  test("append/read to/from a stream") {
     withRedisStream[Unit] { stream =>
       val read  = stream.read(Set("test-stream"))
       val write = stream.append(fs2.Stream(XAddMessage("test-stream", Map("hello" -> "world"))))


### PR DESCRIPTION
Addresses #460 and maybe #445

I guess lettuce api evolved into into using objects and not a string as params and integration broke

The hard thing here would be to choose sane defaults – instead I've exposed the params which is a good thing anyway IMHO.

In the future this will need research and documentation because if I understood the docs correctly:
- passing `block 0` in redis blocks indefinitely (`Duration.Zero` or `Duration.Inf` or both :laughing: ?)
- I did not test/research what lettuce actually does when `0` passed
 
 but for now I think it's better to patch it like this rather than wait
 
 Links:
 - https://redis.io/commands/xread
 - `block 0` in jedis https://github.com/redis/jedis/issues/2277