### PR TITLE
Support for "bitsets" (and bitfields)

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/bits.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/bits.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018-2021 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats.algebra
+
+import dev.profunktor.redis4cats.algebra.BitFieldOperation.BitFieldOp
+
+object BitFieldOperation extends Enumeration {
+  type BitFieldOp = Value
+  val SET, GET = Value
+}
+
+trait BitCommands[F[_], K, V] {
+  def bitField(key: K, operations: (BitFieldOp, String, Long, Int)*): F[Unit]
+}

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -43,6 +43,7 @@ trait Setter[F[_], K, V] {
   def setNx(key: K, value: V): F[Boolean]
   def setEx(key: K, value: V, expiresIn: FiniteDuration): F[Unit]
   def setRange(key: K, value: V, offset: Long): F[Unit]
+  def setBit(key: K, offset: Long, value: Int): F[Long]
 }
 
 trait MultiKey[F[_], K, V] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
@@ -34,6 +34,7 @@ trait RedisCommands[F[_], K, V]
     with ScriptCommands[F, K, V]
     with KeyCommands[F, K]
     with HyperLogLogCommands[F, K, V]
+    with BitCommands[F, K, V]
 
 object RedisCommands {
   implicit class LiftKOps[F[_], K, V](val cmd: RedisCommands[F, K, V]) extends AnyVal {

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisBitSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisBitSetsDemo.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2021 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats
+
+import cats.effect.{ IO, Resource }
+import dev.profunktor.redis4cats.algebra.{ BitFieldOperation, BitFieldOperation }
+import dev.profunktor.redis4cats.effect.Log.NoOp._
+
+object RedisBitSetsDemo extends LoggerIOApp {
+
+  import Demo._
+
+  val program: IO[Unit] = {
+    val testKey = "bitsets"
+
+    val bitsApi: Resource[IO, RedisCommands[IO, String, String]] = Redis[IO].utf8(redisURI)
+
+    bitsApi.use { cmd =>
+      for {
+        _ <- cmd.del(testKey)
+        a <- cmd.setBit(testKey, 7, 1)
+        b <- cmd.setBit(testKey, 7, 0)
+        _ <- putStrLn(s"Before $a after $b")
+        cSet <- cmd.setBit(testKey, 6, 1)
+        _ <- putStrLn(s"Setting offset 6 to $cSet")
+        c <- cmd.getBit(testKey, 6)
+        _ <- putStrLn(s"Bit at offset 6 is $c")
+        batchSet <- for {
+                     s1 <- cmd.setBit("bitmapsarestrings", 2, 1)
+                     s2 <- cmd.setBit("bitmapsarestrings", 3, 1)
+                     s3 <- cmd.setBit("bitmapsarestrings", 5, 1)
+                     s4 <- cmd.setBit("bitmapsarestrings", 10, 1)
+                     s5 <- cmd.setBit("bitmapsarestrings", 11, 1)
+                     s6 <- cmd.setBit("bitmapsarestrings", 14, 1)
+                   } yield s1 + s2 + s3 + s4 + s5 + s6
+        _ <- putStrLn(s"Set multiple ${batchSet}")
+        truth <- cmd.get("bitmapsarestrings")
+        _ <- putStrLn(s"The answer to everything is $truth")
+        bf <- cmd.bitField(
+               "inmap",
+               (BitFieldOperation.SET, "u1", 2, 1),
+               (BitFieldOperation.SET, "u1", 3, 1),
+               (BitFieldOperation.SET, "u1", 5, 1),
+               (BitFieldOperation.SET, "u1", 10, 1),
+               (BitFieldOperation.SET, "u1", 11, 1),
+               (BitFieldOperation.SET, "u1", 14, 1)
+             )
+        _ <- putStrLn("Via bitfield $bf")
+      } yield ()
+    }
+  }
+}


### PR DESCRIPTION
Hello! 👋 

As per some brief discussion in [this issue](https://github.com/profunktor/redis4cats/issues/604) I took the challenge of adding a few Redis commands to redis4cats.

At the moment this PR is still in work-in-progress mode as I have a few questions that we can hopefully resolve before this gets merged.

1. Should I propose this PR against `master` or against any other branch?
2. Although it was recommended that bitmaps should be added to `BitCommands` trait; some methods belong more to `Setters` trait upon my investigation.  😅  Any guidance on that might be welcomed. I did however add method `setBit` there now.
3. The bitfield command needs to be built as a wrapper on top of Lettuce where such interaction is done with the help of [`BitFieldArgs`](https://lettuce.io/core/5.0.0.M2/api/io/lettuce/core/BitFieldArgs.html) - for [`bitfield`](https://lettuce.io/core/5.0.0.M2/api/io/lettuce/core/api/sync/RedisStringCommands.html#bitfield-K-io.lettuce.core.BitFieldArgs-). So I'm wondering how should that abstraction really be made so that it fits well within the design of this lib and Scala ecosystem as such. In the early spike this as seen here you'll see that I thought about using tuples... and ideas there?

I would appreciate some feedback and guidance so that I can finish this.

Thank you and have a nice day!