### PR TITLE
Remove Numeric constraint on incr / decr methods

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
@@ -38,6 +38,6 @@ trait HashSetter[F[_], K, V] {
 }
 
 trait HashIncrement[F[_], K, V] {
-  def hIncrBy(key: K, field: K, amount: Long)(implicit N: Numeric[V]): F[Long]
-  def hIncrByFloat(key: K, field: K, amount: Double)(implicit N: Numeric[V]): F[Double]
+  def hIncrBy(key: K, field: K, amount: Long): F[Long]
+  def hIncrByFloat(key: K, field: K, amount: Double): F[Double]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -50,12 +50,12 @@ trait MultiKey[F[_], K, V] {
 }
 
 trait Decrement[F[_], K, V] {
-  def decr(key: K)(implicit N: Numeric[V]): F[Long]
-  def decrBy(key: K, amount: Long)(implicit N: Numeric[V]): F[Long]
+  def decr(key: K): F[Long]
+  def decrBy(key: K, amount: Long): F[Long]
 }
 
 trait Increment[F[_], K, V] {
-  def incr(key: K)(implicit N: Numeric[V]): F[Long]
-  def incrBy(key: K, amount: Long)(implicit N: Numeric[V]): F[Long]
-  def incrByFloat(key: K, amount: Double)(implicit N: Numeric[V]): F[Double]
+  def incr(key: K): F[Long]
+  def incrBy(key: K, amount: Long): F[Long]
+  def incrByFloat(key: K, amount: Double): F[Double]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -580,31 +580,31 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: RedisExecutor:
   override def setRange(key: K, value: V, offset: Long): F[Unit] =
     async.flatMap(c => RedisExecutor[F].delay(c.setrange(key, offset, value))).futureLift.void
 
-  override def decr(key: K)(implicit N: Numeric[V]): F[Long] =
+  override def decr(key: K): F[Long] =
     async
       .flatMap(c => RedisExecutor[F].delay(c.decr(key)))
       .futureLift
       .map(x => Long.box(x))
 
-  override def decrBy(key: K, amount: Long)(implicit N: Numeric[V]): F[Long] =
+  override def decrBy(key: K, amount: Long): F[Long] =
     async
       .flatMap(c => RedisExecutor[F].delay(c.incrby(key, amount)))
       .futureLift
       .map(x => Long.box(x))
 
-  override def incr(key: K)(implicit N: Numeric[V]): F[Long] =
+  override def incr(key: K): F[Long] =
     async
       .flatMap(c => RedisExecutor[F].delay(c.incr(key)))
       .futureLift
       .map(x => Long.box(x))
 
-  override def incrBy(key: K, amount: Long)(implicit N: Numeric[V]): F[Long] =
+  override def incrBy(key: K, amount: Long): F[Long] =
     async
       .flatMap(c => RedisExecutor[F].delay(c.incrby(key, amount)))
       .futureLift
       .map(x => Long.box(x))
 
-  override def incrByFloat(key: K, amount: Double)(implicit N: Numeric[V]): F[Double] =
+  override def incrByFloat(key: K, amount: Double): F[Double] =
     async
       .flatMap(c => RedisExecutor[F].delay(c.incrbyfloat(key, amount)))
       .futureLift
@@ -707,13 +707,13 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: RedisExecutor:
   override def hmSet(key: K, fieldValues: Map[K, V]): F[Unit] =
     async.flatMap(c => RedisExecutor[F].delay(c.hmset(key, fieldValues.asJava))).futureLift.void
 
-  override def hIncrBy(key: K, field: K, amount: Long)(implicit N: Numeric[V]): F[Long] =
+  override def hIncrBy(key: K, field: K, amount: Long): F[Long] =
     async
       .flatMap(c => RedisExecutor[F].delay(c.hincrby(key, field, amount)))
       .futureLift
       .map(x => Long.box(x))
 
-  override def hIncrByFloat(key: K, field: K, amount: Double)(implicit N: Numeric[V]): F[Double] =
+  override def hIncrByFloat(key: K, field: K, amount: Double): F[Double] =
     async
       .flatMap(c => RedisExecutor[F].delay(c.hincrbyfloat(key, field, amount)))
       .futureLift

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
@@ -16,39 +16,66 @@
 
 package dev.profunktor.redis4cats
 
-import cats.MonadThrow
-import cats.effect.{ IO, Resource }
+import cats.effect.IO
 import dev.profunktor.redis4cats.algebra.StringCommands
+import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.effect.Log.NoOp._
-import dev.profunktor.redis4cats.effect._
+import io.lettuce.core.RedisCommandExecutionException
 
 object RedisStringsDemo extends LoggerIOApp {
-
   import Demo._
 
+  val usernameKey = "test"
+  val numericKey  = "numeric"
+
+  val showResult: Option[String] => IO[Unit] =
+    _.fold(IO.println(s"Not found key: $usernameKey"))(IO.println)
+
+  // simple strings program
+  def p1(redis: StringCommands[IO, String, String]): IO[Unit] =
+    for {
+      x <- redis.get(usernameKey)
+      _ <- showResult(x)
+      _ <- redis.set(usernameKey, "some value")
+      y <- redis.get(usernameKey)
+      _ <- showResult(y)
+      _ <- redis.setNx(usernameKey, "should not happen")
+      w <- redis.get(usernameKey)
+      _ <- showResult(w)
+    } yield ()
+
+  // proof that you can still get it wrong with `incr` and `decr`, even if type-safe
+  def p2(
+      redis: StringCommands[IO, String, String],
+      redisN: StringCommands[IO, String, Long]
+  ): IO[Unit] =
+    for {
+      x <- redis.get(numericKey)
+      _ <- showResult(x)
+      _ <- redis.set(numericKey, "not a number")
+      y <- redis.get(numericKey)
+      _ <- showResult(y)
+      _ <- redisN.incr(numericKey).attempt.flatMap {
+            case Left(e: RedisCommandExecutionException) =>
+              IO(assert(e.getMessage == "ERR value is not an integer or out of range"))
+            case _ =>
+              IO.raiseError(new Exception("Expected error"))
+          }
+      w <- redis.get(numericKey)
+      _ <- showResult(w)
+    } yield ()
+
   val program: IO[Unit] = {
-    val usernameKey = "test"
+    val res = for {
+      cli <- RedisClient[IO].from(redisURI)
+      rd1 <- Redis[IO].fromClient(cli, stringCodec)
+      rd2 <- Redis[IO].fromClient(cli, longCodec)
+    } yield rd1 -> rd2
 
-    val showResult: Option[String] => IO[Unit] =
-      _.fold(putStrLn(s"Not found key: $usernameKey"))(s => putStrLn(s))
-
-    // can also be created abstracting over F[_]
-    def commandsApi[F[_]: MkRedis: MonadThrow]: Resource[F, StringCommands[F, String, String]] =
-      Redis[F].utf8(redisURI)
-
-    commandsApi[IO]
-      .use { cmd =>
-        for {
-          x <- cmd.get(usernameKey)
-          _ <- showResult(x)
-          _ <- cmd.set(usernameKey, "some value")
-          y <- cmd.get(usernameKey)
-          _ <- showResult(y)
-          _ <- cmd.setNx(usernameKey, "should not happen")
-          w <- cmd.get(usernameKey)
-          _ <- showResult(w)
-        } yield ()
-      }
+    res.use {
+      case (rd1, rd2) =>
+        p1(rd1) *> p2(rd1, rd2)
+    }
   }
 
 }


### PR DESCRIPTION
Now that I am making heavy use of Redis, I've come to realize the `Numeric` constraint on methods such as `incr` and `decr` was a mistake. 

The original idea was that it made the API much safer. For instance, if we try to increase the value of a key by calling `incr`, then you need a `RedisCommands[F, String, Int]` (or some other numeric type), because we cannot increase the value of a String or a Boolean, for instance. If we try, we are faced with an exception.

The idea was honest but I realized that it's very easy to break these guarantees directly from the code, as demonstrated in the following example. 

```scala
def p2(
    redis: StringCommands[IO, String, String],
    redisN: StringCommands[IO, String, Long]
): IO[Unit] =
  redis.set("numeric", "not a number") *>
    redisN.incr(numericKey).attempt.flatMap {
      case Left(e: RedisCommandExecutionException) =>
        IO(assert(e.getMessage == "ERR value is not an integer or out of range"))
      case _ =>
        IO.raiseError(new Exception("Expected error"))
    }
 ```

Up until now I needed to create two `RedisCommands`: one with `String` values, other with `Long` values to use with `incr` and friends, but even when using a different "safer" instance with the proper types, the `incr` and `decr` methods are still UNSAFE. We can break the safety from the code but it can also break from outside access to Redis as well.

So to simplify the usage of this library, I'm removing the `Numeric` constraint. The only downside of this change is that it probably breaks binary compatibility, but it's a necessary change.
