### PR TITLE
Pipelining redis streams producer on chunk

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.watcherExclude": {
+    "**/target": true
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,7 @@ lazy val `redis4cats-streams` = project
   .settings(Test / parallelExecution := false)
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(`redis4cats-core`)
+  .dependsOn(`redis4cats-effects`)
 
 lazy val examples = project
   .in(file("modules/examples"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,23 @@
-SingleNode:
-  restart: always
-  image: redis:6.0.8
-  ports:
-    - "6379:6379"
-  environment:
-    - DEBUG=false
+version: '3'
+services:
+  SingleNode:
+    restart: always
+    image: redis:6.0.8
+    ports:
+      - "6379:6379"
+    environment:
+      - DEBUG=false
 
-RedisCluster:
-  restart: always
-  image: grokzen/redis-cluster:6.0.8
-  ports:
-    - "30001:30001"
-    - "30002:30002"
-    - "30003:30003"
-    - "30004:30004"
-    - "30005:30005"
-    - "30006:30006"
-  environment:
-    - INITIAL_PORT=30001
-    - DEBUG=false
+  RedisCluster:
+    restart: always
+    image: grokzen/redis-cluster:6.0.8
+    ports:
+      - "30001:30001"
+      - "30002:30002"
+      - "30003:30003"
+      - "30004:30004"
+      - "30005:30005"
+      - "30006:30006"
+    environment:
+      - INITIAL_PORT=30001
+      - DEBUG=false

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/Fs2Streaming.scala
@@ -17,9 +17,11 @@
 package dev.profunktor.redis4cats
 package streams
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 import cats.effect.kernel._
+import cats.effect.kernel.implicits._
+import cats._
 import cats.syntax.all._
 import dev.profunktor.redis4cats.connection._
 import dev.profunktor.redis4cats.data._
@@ -72,7 +74,8 @@ object RedisStream {
 
 }
 
-class RedisStream[F[_]: Sync, K, V](rawStreaming: RedisRawStreaming[F, K, V]) extends Streaming[Stream[F, *], K, V] {
+class RedisStream[F[_]: Async: Log, K, V](rawStreaming: RedisRawStreaming[F, K, V])
+    extends Streaming[Stream[F, *], K, V] {
 
   private[streams] val nextOffset: K => XReadMessage[K, V] => StreamingOffset[K] =
     key => msg => StreamingOffset.Custom(key, msg.id.value)
@@ -80,8 +83,78 @@ class RedisStream[F[_]: Sync, K, V](rawStreaming: RedisRawStreaming[F, K, V]) ex
   private[streams] val offsetsByKey: List[XReadMessage[K, V]] => Map[K, Option[StreamingOffset[K]]] =
     list => list.groupBy(_.key).map { case (k, values) => k -> values.lastOption.map(nextOffset(k)) }
 
+  private val promiseAlreadyCompleted = new AssertionError("Promise already completed")
+
+  // Joins or cancel fiberss correspondent to previous executed commands
+  private def joinOrCancel[A](ys: List[Fiber[F, Throwable, A]], res: List[A])(isJoin: Boolean): F[List[A]] =
+    ys match {
+      case h :: t if isJoin =>
+        h.joinWithNever.flatMap(x => joinOrCancel(t, x :: res)(isJoin))
+      case h :: t =>
+        h.cancel.flatMap(_ => joinOrCancel(t, res)(isJoin))
+      case Nil => Applicative[F].pure(res)
+    }
+
+  // Forks every command in order
+  private def runner[H](
+      f: F[Unit],
+      cmds: List[F[H]],
+      res: List[Fiber[F, Throwable, H]]
+  ): F[List[Fiber[F, Throwable, H]]] =
+    cmds match {
+      case Nil    => res.pure[F]
+      case h :: t => (h, f).parTupled.map(_._1).start.flatMap(fb => runner(f, t, fb :: res))
+    }
+
   override def append: Stream[F, XAddMessage[K, V]] => Stream[F, MessageId] =
-    _.evalMap(msg => rawStreaming.xAdd(msg.key, msg.body, msg.approxMaxlen))
+    _.chunks
+      .evalMap { chunk =>
+        Deferred[F, Either[Throwable, List[MessageId]]].flatMap {
+          case promise =>
+            def cancelFibers[A](fibs: List[Fiber[F, Throwable, MessageId]])(err: Throwable): F[Unit] =
+              joinOrCancel(fibs, List.empty)(false) >> promise
+                    .complete(err.asLeft)
+                    .ensure(promiseAlreadyCompleted)(identity)
+                    .void
+
+            def onErrorOrCancelation(fibs: List[Fiber[F, Throwable, MessageId]]): F[Unit] =
+              cancelFibers(fibs)(new RuntimeException("XADD cancelled"))
+
+            (Deferred[F, Unit], Ref.of[F, Int](0)).tupled
+              .flatMap {
+                case (gate, counter) =>
+                  val commands = chunk.map(msg => rawStreaming.xAdd(msg.key, msg.body, msg.approxMaxlen))
+
+                  // wait for commands to be scheduled
+                  val synchronizer: F[Unit] =
+                    counter.modify {
+                      case n if n === (commands.size - 1) =>
+                        n + 1 -> gate.complete(()).ensure(promiseAlreadyCompleted)(identity).void
+                      case n => n + 1 -> Applicative[F].unit
+                    }.flatten
+
+                  Log[F].debug(s"XADD started with size: ${commands.size}") >>
+                    (rawStreaming.disableAutoFlush >> runner(synchronizer, commands.toList, List.empty))
+                      .bracketCase(_ => gate.get) {
+                        case (fibs, Outcome.Succeeded(_)) =>
+                          for {
+                            _ <- Log[F].debug(s"XADD flushing ${commands.size} commands...")
+                            _ <- rawStreaming.flushCommands
+                            _ <- Log[F].debug(s"XADD awaiting all ${commands.size} commands...")
+                            r <- joinOrCancel(fibs, List.empty)(true)
+                            _ <- promise.complete(r.asRight).ensure(promiseAlreadyCompleted)(identity)
+                          } yield ()
+                        case (fibs, Outcome.Errored(e)) =>
+                          Log[F].error(s"XADD failed: ${e.getMessage}") >> onErrorOrCancelation(fibs)
+                        case (fibs, Outcome.Canceled()) =>
+                          Log[F].error(s"XADD canceled") >> onErrorOrCancelation(fibs)
+                      }
+                      // .guarantee(rawStreaming.enableAutoFlush) >> promise.get.rethrow.timeout(3.seconds)
+                      .guarantee(Applicative[F].unit) >> promise.get.rethrow.timeout(3.seconds)
+              }
+        }
+      }
+      .flatMap(Stream.emits)
 
   override def read(
       keys: Set[K],

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
@@ -17,10 +17,11 @@
 package dev.profunktor.redis4cats.streams
 
 import data._
+import dev.profunktor.redis4cats.algebra._
 
 import scala.concurrent.duration.Duration
 
-trait RawStreaming[F[_], K, V] {
+trait RawStreaming[F[_], K, V] extends AutoFlush[F] {
 
   /**
     * @param approxMaxlen does XTRIM ~ maxlen if defined

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration.DurationInt
 class RedisStreamSpec extends Redis4CatsFunSuite(false) {
 
   // FIXME: Flaky test -> https://github.com/profunktor/redis4cats/issues/460
-  test("append/read to/from a stream".ignore) {
+  test("append/read to/from a stream") {
     withRedisStream[Unit] { stream =>
       val read  = stream.read(Set("test-stream"), 1)
       val write = stream.append(fs2.Stream(XAddMessage("test-stream", Map("hello" -> "world"))))

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,0 +1,6 @@
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.11-17-f4ef8273")
+

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,0 +1,6 @@
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.11-17-f4ef8273")
+

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,0 +1,6 @@
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.11-17-f4ef8273")
+


### PR DESCRIPTION
Aims to support https://github.com/profunktor/redis4cats/issues/631

Unfortunately I am running into deadlocks after 5-10 seconds of running a simple program like follows:
```scala
object RedisProducer extends IOApp {
  override def run(args: List[String]): IO[ExitCode] = {
    implicit def log: Logger[IO] = Slf4jLogger.getLogger[IO]

    RedisClient[IO]
      .from("redis://localhost")
      .flatMap(client => RedisStream.mkStreamingConnectionResource[IO, String, String](client, stringCodec))
      .flatMap { streaming =>
        val redisAppend = streaming.append
        Stream
          .awakeEvery[IO](100.micro)
          .evalMap(_ => randomMessage)
          .groupWithin(5, 10.milli)
          .unchunks
          .through(streaming.append)
          .logAverageRate(rate => IO.println(s"Producer rate: $rate"))
          // .evalMap(putStrLn(_))
          .compile
          .drain
          .background
      }
      .use(combined => IO.readLine)
      .redeem(
        { t =>
          log.error(t)("Something went wrong")
          ExitCode(1)
        },
        _ => ExitCode.Success
      )
  }
}
```