### PR TITLE
Add variadic hSet and deprecate hmSet

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
@@ -33,7 +33,10 @@ trait HashGetter[F[_], K, V] {
 
 trait HashSetter[F[_], K, V] {
   def hSet(key: K, field: K, value: V): F[Boolean]
+  def hSet(key: K, fieldValues: Map[K, V]): F[Long]
   def hSetNx(key: K, field: K, value: V): F[Boolean]
+
+  @deprecated("In favor of hSet(key: K, fieldValues: Map[K, V])", since = "1.0.1")
   def hmSet(key: K, fieldValues: Map[K, V]): F[Unit]
 }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -696,6 +696,12 @@ private[redis4cats] class BaseRedis[F[_]: Concurrent: ContextShift: RedisExecuto
   override def hSet(key: K, field: K, value: V): F[Boolean] =
     async.flatMap(c => RedisExecutor[F].delay(c.hset(key, field, value))).futureLift.map(x => Boolean.box(x))
 
+  override def hSet(key: K, fieldValues: Map[K, V]): F[Long] =
+    async
+      .flatMap(c => RedisExecutor[F].delay(c.hset(key, fieldValues.asJava)))
+      .futureLift
+      .map(x => Long.box(x))
+
   override def hSetNx(key: K, field: K, value: V): F[Boolean] =
     async
       .flatMap(c => RedisExecutor[F].delay(c.hsetnx(key, field, value)))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -81,6 +81,11 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assertEquals(d, 1L))
       z <- cmd.hGet(testKey, testField)
       _ <- IO(assert(z.isEmpty))
+      _ <- cmd.hSet(testKey, Map(testField -> "some value", testField2 -> "another value"))
+      v <- cmd.hGet(testKey, testField)
+      _ <- IO(assert(v.contains("some value")))
+      v <- cmd.hGet(testKey, testField2)
+      _ <- IO(assert(v.contains("another value")))
     } yield ()
   }
 


### PR DESCRIPTION
As per Redis docs (https://redis.io/commands/HMSET):

> As per Redis 4.0.0, HMSET is considered deprecated.
> Please prefer HSET in new code.

Fixes https://github.com/profunktor/redis4cats/issues/639.