### PR TITLE
Added support for commands: zunion, zinter, zdiff, smismember

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ Start both a single Redis node and a cluster using `docker-compose`:
 > sbt +test
 ```
 
+If you are trying to run cluster mode tests on macOS you might receive host not found errors. As a workaround add
+new environment variable in `docker-compose.yml` for `RedisCluster`: `IP=0.0.0.0`
+
+The environment section should look like this:
+```
+    environment:
+      - INITIAL_PORT=30001
+      - DEBUG=false
+      - IP=0.0.0.0
+```
+
 ## Code of Conduct
 
 See the [Code of Conduct](https://redis4cats.profunktor.dev/CODE_OF_CONDUCT)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,23 @@
-SingleNode:
-  restart: always
-  image: redis:6.0.8
-  ports:
-    - "6379:6379"
-  environment:
-    - DEBUG=false
+version: "3.0"
+services:
+  SingleNode:
+    restart: always
+    image: redis:6.2.0
+    ports:
+      - "6379:6379"
+    environment:
+      - DEBUG=false
 
-RedisCluster:
-  restart: always
-  image: grokzen/redis-cluster:6.0.8
-  ports:
-    - "30001:30001"
-    - "30002:30002"
-    - "30003:30003"
-    - "30004:30004"
-    - "30005:30005"
-    - "30006:30006"
-  environment:
-    - INITIAL_PORT=30001
-    - DEBUG=false
+  RedisCluster:
+    restart: always
+    image: grokzen/redis-cluster:6.2.0
+    ports:
+      - "30001:30001"
+      - "30002:30002"
+      - "30003:30003"
+      - "30004:30004"
+      - "30005:30005"
+      - "30006:30006"
+    environment:
+      - INITIAL_PORT=30001
+      - DEBUG=false

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sets.scala
@@ -18,6 +18,7 @@ package dev.profunktor.redis4cats.algebra
 
 trait SetCommands[F[_], K, V] extends SetGetter[F, K, V] with SetSetter[F, K, V] with SetDeletion[F, K, V] {
   def sIsMember(key: K, value: V): F[Boolean]
+  def sMisMember(key: K, values: V*): F[List[Boolean]]
 }
 
 trait SetGetter[F[_], K, V] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
@@ -18,7 +18,7 @@ package dev.profunktor.redis4cats.algebra
 
 import cats.data.NonEmptyList
 import dev.profunktor.redis4cats.effects.{ RangeLimit, ScoreWithValue, ZRange }
-import io.lettuce.core.{ ZAddArgs, ZStoreArgs }
+import io.lettuce.core.{ ZAddArgs, ZAggregateArgs, ZStoreArgs }
 
 import scala.concurrent.duration.Duration
 
@@ -53,6 +53,12 @@ trait SortedSetGetter[F[_], K, V] {
   def zPopMax(key: K, count: Long): F[List[ScoreWithValue[V]]]
   def bzPopMax(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
   def bzPopMin(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
+  def zUnion(args: Option[ZAggregateArgs], keys: K*): F[List[V]]
+  def zUnionWithScores(args: Option[ZAggregateArgs], keys: K*): F[List[ScoreWithValue[V]]]
+  def zInter(args: Option[ZAggregateArgs], keys: K*): F[List[V]]
+  def zInterWithScores(args: Option[ZAggregateArgs], keys: K*): F[List[ScoreWithValue[V]]]
+  def zDiff(keys: K*): F[List[V]]
+  def zDiffWithScores(keys: K*): F[List[ScoreWithValue[V]]]
 }
 
 trait SortedSetSetter[F[_], K, V] {


### PR DESCRIPTION
Hello

There are new commands in redis 6.2 that I need, but sadly aren't supported by redis4cats. I added support to some of them. My changes:
- Updated redis images to 6.2 to support new commands added
- New commands: `zunion`, `zinter`, `zdiff`, `smismember`
- I had some problems running `docker-compose up` to run tests locally. The reason was outdated format of `docker-compose.yml` file. Newer versions of docker-compose runner default to newer format version, which requires to list all containers under `services` section. I updated the file and was able to run the tests successfully.
- There was also one more change, but I decided not to commit it as it's macOS specific. For the cluster tests to run I had to define additional environment variable for `grokzen/redis-cluster`: `IP=0.0.0.0`. I have no way to test if it breaks something on other operating systems, so for now I only added notes to readme.