### PR TITLE
Update JDK version in `.mergify.yaml`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,8 +8,8 @@ pull_request_rules:
   - name: automatically merge Scala Steward PRs on CI success
     conditions:
       - author=scala-steward
-      - "status-success=Build (jdk11)"
-      - "status-success=Build (jdk15)"
+      - "check-success=Build (jdk11)"
+      - "check-success=Build (jdk17)"
     actions:
       merge:
         method: merge


### PR DESCRIPTION
I thought we might want to update the config to enable for automatic merges by `scala-steward`.

If there's a reason that this wasn't updated feel free to close it!