### PR TITLE
fix zrevrangebyscoreWithScores implementation

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1354,7 +1354,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: RedisExecutor:
         async.flatMap(c =>
           RedisExecutor[F].delay(c.zrevrangebyscoreWithScores(key, range.asJavaRange, JLimit.create(x.offset, x.count)))
         )
-      case None => async.flatMap(c => RedisExecutor[F].delay(c.zrangebyscoreWithScores(key, range.asJavaRange)))
+      case None => async.flatMap(c => RedisExecutor[F].delay(c.zrevrangebyscoreWithScores(key, range.asJavaRange)))
     }
     res.futureLift.map(_.asScala.toList.map(_.asScoreWithValues))
   }


### PR DESCRIPTION
this MR fixes `zRevRangeByScoreWithScores` implementation.
the code before fix:

```scala
override def zRevRangeByScoreWithScores[T: Numeric](...): F[List[ScoreWithValue[V]]] = {
    val res = limit match {
      case Some(x) => ...
      case None => async.flatMap(c => RedisExecutor[F].delay(c.zrangebyscoreWithScores(key, range.asJavaRange)))
    }
    res.futureLift.map(_.asScala.toList.map(_.asScoreWithValues))
  }
```
notice the usage of `zrangebyscoreWithScores` instead of `zrangebyscoreWithScores`.


`zRevRangeByScoreWithScores` will be deprecated soon (https://redis.io/commands/ZREVRANGEBYSCORE), should I use `ZRANGE` with the `REV` and `BYSCORE` arguments instead ?
