### PR TITLE
examples: add redis master-replica connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,17 @@ services:
     environment:
       - DEBUG=false
 
+  ReplicaNode:
+    restart: always
+    image: redis:6.2.0
+    ports:
+      - "6380:6379"
+    command: redis-server --replicaof SingleNode 6379
+    links:
+      - SingleNode:SingleNode
+    environment:
+      - DEBUG=false
+
   RedisCluster:
     restart: always
     image: grokzen/redis-cluster:6.2.0

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/server.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/server.scala
@@ -27,6 +27,7 @@ trait Flush[F[_], K] {
 
 trait Diagnostic[F[_]] {
   def info: F[Map[String, String]]
+  def info(section: String): F[Map[String, String]]
   def dbsize: F[Long]
   def lastSave: F[Instant]
   def slowLogLen: F[Long]


### PR DESCRIPTION
```scala
sbt] redis4cats λ examples/runMain dev.profunktor.redis4cats.RedisMasterReplicaStringsDemo
[info] running dev.profunktor.redis4cats.RedisMasterReplicaStringsDemo
SERVER INFO
(second_repl_offset,-1)
(master_failover_state,no-failover)
(master_port,6379)
(master_repl_offset,114)
(master_last_io_seconds_ago,3)
(master_host,SingleNode)
(master_replid2,0000000000000000000000000000000000000000)
(repl_backlog_size,1048576)
(repl_backlog_first_byte_offset,1)
(slave_priority,100)
(master_replid,12c1b26409139e54056772bba23028a2d9e40de4)
(slave_repl_offset,114)
(connected_slaves,0)
(master_link_status,up)
(role,slave)
(repl_backlog_active,1)
(master_sync_in_progress,0)
(repl_backlog_histlen,114)
(slave_read_only,1)
----------
Not found key: test
some value
some value
Not found key: test
[success] Total time: 1 s, completed Apr 24, 2022, 10:41:28 AM
```