### PR TITLE
Add psubscribe/punsubscribe to PubSub api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "6379:6379"
     environment:
       - DEBUG=false
+    command: redis-server --notify-keyspace-events KEA
 
   ReplicaNode:
     restart: always

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/data.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/data.scala
@@ -28,6 +28,8 @@ import javax.crypto.spec.SecretKeySpec
 object data {
 
   final case class RedisChannel[K](underlying: K) extends AnyVal
+  final case class RedisPattern[K](underlying: K) extends AnyVal
+  final case class RedisPatternEvent[K, V](pattern: K, channel: K, data: V)
 
   final case class RedisCodec[K, V](underlying: JRedisCodec[K, V]) extends AnyVal
   final case class NodeId(value: String) extends AnyVal

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSubCommands.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSubCommands.scala
@@ -33,6 +33,8 @@ trait PublishCommands[F[_], K, V] extends PubSubStats[F, K] {
 trait SubscribeCommands[F[_], K, V] {
   def subscribe(channel: RedisChannel[K]): F[V]
   def unsubscribe(channel: RedisChannel[K]): F[Unit]
+  def psubscribe(channel: RedisPattern[K]): F[RedisPatternEvent[K, V]]
+  def punsubscribe(channel: RedisPattern[K]): F[Unit]
 }
 
 trait PubSubCommands[F[_], K, V] extends PublishCommands[F, K, V] with SubscribeCommands[F, K, V]

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubInternals.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubInternals.scala
@@ -20,49 +20,82 @@ import cats.effect.kernel.{ Async, Ref, Resource, Sync }
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
 import dev.profunktor.redis4cats.data.RedisChannel
+import dev.profunktor.redis4cats.data.RedisPattern
+import dev.profunktor.redis4cats.data.RedisPatternEvent
 import dev.profunktor.redis4cats.effect.Log
 import fs2.concurrent.Topic
 import io.lettuce.core.pubsub.{ RedisPubSubListener, StatefulRedisPubSubConnection }
+import io.lettuce.core.pubsub.RedisPubSubAdapter
 
 object PubSubInternals {
 
-  private[redis4cats] def defaultListener[F[_]: Async, K, V](
+  private[redis4cats] def channelListener[F[_]: Async, K, V](
       channel: RedisChannel[K],
       topic: Topic[F, Option[V]],
       dispatcher: Dispatcher[F]
   ): RedisPubSubListener[K, V] =
-    new RedisPubSubListener[K, V] {
+    new RedisPubSubAdapter[K, V] {
       override def message(ch: K, msg: V): Unit =
         if (ch == channel.underlying) {
           dispatcher.unsafeRunSync(topic.publish1(Option(msg)).void)
         }
       override def message(pattern: K, channel: K, message: V): Unit = this.message(channel, message)
-      override def psubscribed(pattern: K, count: Long): Unit        = ()
-      override def subscribed(channel: K, count: Long): Unit         = ()
-      override def unsubscribed(channel: K, count: Long): Unit       = ()
-      override def punsubscribed(pattern: K, count: Long): Unit      = ()
+    }
+  private[redis4cats] def patternListener[F[_]: Async, K, V](
+      redisPattern: RedisPattern[K],
+      topic: Topic[F, Option[RedisPatternEvent[K, V]]],
+      dispatcher: Dispatcher[F]
+  ): RedisPubSubListener[K, V] =
+    new RedisPubSubAdapter[K, V] {
+      override def message(pattern: K, channel: K, message: V): Unit =
+        if (pattern == redisPattern.underlying) {
+          dispatcher.unsafeRunSync(topic.publish1(Option(RedisPatternEvent(pattern, channel, message))).void)
+        }
     }
 
-  private[redis4cats] def apply[F[_]: Async: Log, K, V](
+  private[redis4cats] def channel[F[_]: Async: Log, K, V](
       state: Ref[F, PubSubState[F, K, V]],
       subConnection: StatefulRedisPubSubConnection[K, V]
   ): GetOrCreateTopicListener[F, K, V] = { channel => st =>
-    st.get(channel.underlying)
+    st.channels
+      .get(channel.underlying)
       .fold {
         for {
           dispatcher <- Dispatcher[F]
           topic <- Resource.eval(Topic[F, Option[V]])
           _ <- Resource.eval(Log[F].info(s"Creating listener for channel: $channel"))
-          listener = defaultListener(channel, topic, dispatcher)
+          listener = channelListener(channel, topic, dispatcher)
           _ <- Resource.make {
                 Sync[F].delay(subConnection.addListener(listener)) *>
-                  state.update(_.updated(channel.underlying, topic))
+                  state.update(s => s.copy(channels = s.channels.updated(channel.underlying, topic)))
               } { _ =>
                 Sync[F].delay(subConnection.removeListener(listener)) *>
-                  state.update(_ - channel.underlying)
+                  state.update(s => s.copy(channels = s.channels - channel.underlying))
               }
         } yield topic
       }(Resource.pure)
   }
 
+  private[redis4cats] def pattern[F[_]: Async: Log, K, V](
+      state: Ref[F, PubSubState[F, K, V]],
+      subConnection: StatefulRedisPubSubConnection[K, V]
+  ): GetOrCreatePatternListener[F, K, V] = { channel => st =>
+    st.patterns
+      .get(channel.underlying)
+      .fold {
+        for {
+          dispatcher <- Dispatcher[F]
+          topic <- Resource.eval(Topic[F, Option[RedisPatternEvent[K, V]]])
+          _ <- Resource.eval(Log[F].info(s"Creating listener for pattern: $channel"))
+          listener = patternListener(channel, topic, dispatcher)
+          _ <- Resource.make {
+                Sync[F].delay(subConnection.addListener(listener)) *>
+                  state.update(s => s.copy(patterns = s.patterns.updated(channel.underlying, topic)))
+              } { _ =>
+                Sync[F].delay(subConnection.removeListener(listener)) *>
+                  state.update(s => s.copy(patterns = s.patterns - channel.underlying))
+              }
+        } yield topic
+      }(Resource.pure)
+  }
 }

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubState.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubState.scala
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
-package dev.profunktor.redis4cats.pubsub
-
-import cats.effect.kernel.Resource
-import dev.profunktor.redis4cats.data.RedisChannel
+package dev.profunktor.redis4cats.pubsub.internals
 import fs2.concurrent.Topic
-import dev.profunktor.redis4cats.data.RedisPattern
 import dev.profunktor.redis4cats.data.RedisPatternEvent
-
-package object internals {
-  private[pubsub] type GetOrCreateTopicListener[F[_], K, V] =
-    RedisChannel[K] => PubSubState[F, K, V] => Resource[F, Topic[F, Option[V]]]
-
-  private[pubsub] type GetOrCreatePatternListener[F[_], K, V] =
-    RedisPattern[K] => PubSubState[F, K, V] => Resource[F, Topic[F, Option[RedisPatternEvent[K, V]]]]
-}
+final case class PubSubState[F[_], K, V](
+    channels: Map[K, Topic[F, Option[V]]],
+    patterns: Map[K, Topic[F, Option[RedisPatternEvent[K, V]]]]
+)

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
@@ -47,6 +47,9 @@ abstract class Redis4CatsFunSuite(isCluster: Boolean) extends IOSuite {
   def withRedis[A](f: RedisCommands[IO, String, String] => IO[A]): Future[Unit] =
     withAbstractRedis[A, String, String](f)(stringCodec)
 
+  def withRedisClient[A](f: RedisClient => IO[A]): Future[Unit] =
+    RedisClient[IO].from("redis://localhost").use(f).as(assert(true)).unsafeToFuture()
+
   def withRedisStream[A](f: Streaming[fs2.Stream[IO, *], String, String] => IO[A]): Future[Unit] =
     (for {
       client <- fs2.Stream.resource(RedisClient[IO].from("redis://localhost"))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
@@ -50,6 +50,10 @@ class RedisSpec extends Redis4CatsFunSuite(false) with TestScenarios {
 
   test("hyperloglog api")(withRedis(hyperloglogScenario))
 
+  test("pattern key sub")(withRedisClient(keyPatternSubScenario))
+
+  test("pattern channel sub")(withRedisClient(channelPatternSubScenario))
+
 }
 
 object LongCodec extends JRedisCodec[String, Long] with ToByteBufEncoder[String, Long] {


### PR DESCRIPTION
Hello :-)

This PR adds support for PSUBSCRIBE/PUNSUBSCRIBE commands to the PubSub api. They function in roughly the same way as channel pubsub works today.

Be aware that pattern subscriptions to keyspace events require that
keyspace event notifications are enabled. In clusters, it is also
necessary to subscribe to keyspace notifications on each individual
redis node, since keyspace events are not broadcast across the cluster.
See https://redis.io/docs/manual/keyspace-notifications/#events-in-a-cluster.