### PR TITLE
Add support for KEEPTTL option in SET command

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -124,7 +124,7 @@ object effects {
       case class Ex(duration: FiniteDuration) extends Ttl
 
       /** Set KeepTtl */
-      case object KeepTtl extends Ttl
+      case object Keep extends Ttl
     }
   }
   case class SetArgs(existence: Option[SetArg.Existence], ttl: Option[SetArg.Ttl])

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -122,6 +122,9 @@ object effects {
 
       /** Set Expiration in Seconds */
       case class Ex(duration: FiniteDuration) extends Ttl
+
+      /** Set KeepTtl */
+      case object KeepTtl extends Ttl
     }
   }
   case class SetArgs(existence: Option[SetArg.Existence], ttl: Option[SetArg.Ttl])

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -528,7 +528,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     setArgs.ttl.foreach {
       case SetArg.Ttl.Px(d) => jSetArgs.px(d.toMillis)
       case SetArg.Ttl.Ex(d) => jSetArgs.ex(d.toSeconds)
-      case SetArg.Ttl.KeepTtl => jSetArgs.keepttl()
+      case SetArg.Ttl.Keep => jSetArgs.keepttl()
     }
 
     async.flatMap(_.set(key, value, jSetArgs).futureLift.map(_ == "OK"))

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -528,6 +528,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     setArgs.ttl.foreach {
       case SetArg.Ttl.Px(d) => jSetArgs.px(d.toMillis)
       case SetArg.Ttl.Ex(d) => jSetArgs.ex(d.toSeconds)
+      case SetArg.Ttl.KeepTtl => jSetArgs.keepttl()
     }
 
     async.flatMap(_.set(key, value, jSetArgs).futureLift.map(_ == "OK"))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -264,7 +264,7 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assertEquals(k, true))
       kTtl <-  redis.ttl("k")
       _ <- IO(assert(kTtl.nonEmpty))
-      _ <- redis.set("k", "v", SetArgs(SetArg.Ttl.KeepTtl))
+      _ <- redis.set("k", "v", SetArgs(SetArg.Ttl.Keep))
       kv <- redis.get("k")
       _ <- IO(assertEquals(kv, Some("v")))
       kTtl2 <- redis.ttl("k")

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -260,6 +260,16 @@ trait TestScenarios { self: FunSuite =>
       j <- redis.expire("_not_existing_key_", 50.millis)
       _ <- IO(assertEquals(j, false))
       _ <- redis.del("f1")
+      k <- redis.set("k", "", SetArgs(SetArg.Ttl.Ex(10.seconds)))
+      _ <- IO(assertEquals(k, true))
+      kTtl <-  redis.ttl("k")
+      _ <- IO(assert(kTtl.nonEmpty))
+      _ <- redis.set("k", "v", SetArgs(SetArg.Ttl.KeepTtl))
+      kv <- redis.get("k")
+      _ <- IO(assert(kv.nonEmpty && kv.exists(_==="v")))
+      kTtl2 <- redis.ttl("k")
+      _ <- IO(assert(kTtl2.nonEmpty))
+      _ <- redis.del("k")
     } yield ()
   }
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -266,7 +266,7 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assert(kTtl.nonEmpty))
       _ <- redis.set("k", "v", SetArgs(SetArg.Ttl.KeepTtl))
       kv <- redis.get("k")
-      _ <- IO(assert(kv.nonEmpty && kv.exists(_==="v")))
+      _ <- IO(assertEquals(kv, Some("v")))
       kTtl2 <- redis.ttl("k")
       _ <- IO(assert(kTtl2.nonEmpty))
       _ <- redis.del("k")


### PR DESCRIPTION
Hello,

This PR simply adds support for KEEPTTL option in the [SET](https://redis.io/commands/set/). 

`KeepTtl` has just been added as another TTL option, in accordance with the documented SET command syntax.

Usage example:

```scala
redis.set("key", "value", SetArgs(SetArg.Ttl.KeepTtl))
```