### PR TITLE
Update Lettuce to `6.2.1.RELEASE` and fix deprecations

### DIFF
--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisConnection.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisConnection.scala
@@ -41,6 +41,8 @@ private[redis4cats] trait RedisConnection[F[_], K, V] {
   def close: F[Unit]
   def byNode(nodeId: NodeId): F[RedisAsyncCommands[K, V]]
   def liftK[G[_]: Async]: RedisConnection[G, K, V]
+  private[redis4cats] def setAutoFlushCommands(autoFlush: Boolean): F[Unit]
+  private[redis4cats] def flushCommands: F[Unit]
 }
 
 private[redis4cats] class RedisStatefulConnection[F[_]: ApplicativeThrow: FutureLift, K, V](
@@ -57,6 +59,9 @@ private[redis4cats] class RedisStatefulConnection[F[_]: ApplicativeThrow: Future
     OperationNotSupported("Running in a single node").raiseError
   def liftK[G[_]: Async]: RedisConnection[G, K, V] =
     new RedisStatefulConnection[G, K, V](conn)
+  private[redis4cats] def setAutoFlushCommands(autoFlush: Boolean): F[Unit] =
+    FutureLift[F].delay(conn.setAutoFlushCommands(autoFlush))
+  private[redis4cats] def flushCommands: F[Unit] = FutureLift[F].delay(conn.flushCommands())
 }
 
 private[redis4cats] class RedisStatefulClusterConnection[F[_]: FutureLift: MonadThrow, K, V](
@@ -75,4 +80,7 @@ private[redis4cats] class RedisStatefulClusterConnection[F[_]: FutureLift: Monad
     }
   def liftK[G[_]: Async]: RedisConnection[G, K, V] =
     new RedisStatefulClusterConnection[G, K, V](conn)
+  private[redis4cats] def setAutoFlushCommands(autoFlush: Boolean): F[Unit] =
+    FutureLift[F].delay(conn.setAutoFlushCommands(autoFlush))
+  private[redis4cats] def flushCommands: F[Unit] = FutureLift[F].delay(conn.flushCommands())
 }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisConnection.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisConnection.scala
@@ -61,7 +61,7 @@ private[redis4cats] class RedisStatefulConnection[F[_]: ApplicativeThrow: Future
     new RedisStatefulConnection[G, K, V](conn)
   private[redis4cats] def setAutoFlushCommands(autoFlush: Boolean): F[Unit] =
     FutureLift[F].delay(conn.setAutoFlushCommands(autoFlush))
-  private[redis4cats] def flushCommands: F[Unit] = FutureLift[F].delay(conn.flushCommands())
+  private[redis4cats] def flushCommands: F[Unit] = FutureLift[F].blocking(conn.flushCommands())
 }
 
 private[redis4cats] class RedisStatefulClusterConnection[F[_]: FutureLift: MonadThrow, K, V](

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/FutureLift.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/FutureLift.scala
@@ -26,6 +26,7 @@ import java.util.concurrent._
 
 private[redis4cats] trait FutureLift[F[_]] {
   def delay[A](thunk: => A): F[A]
+  def blocking[A](thunk: => A): F[A]
   def guarantee[A](fa: F[A], fu: F[Unit]): F[A]
   def lift[A](fa: => RedisFuture[A]): F[A]
   def liftConnectionFuture[A](fa: => ConnectionFuture[A]): F[A]
@@ -42,6 +43,8 @@ object FutureLift {
       val F = Async[F]
 
       def delay[A](thunk: => A): F[A] = F.delay(thunk)
+
+      def blocking[A](thunk: => A): F[A] = F.blocking(thunk)
 
       def guarantee[A](fa: F[A], fu: F[Unit]): F[A] = fa.guarantee(fu)
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -18,7 +18,7 @@ package dev.profunktor.redis4cats.algebra
 
 import scala.concurrent.duration.FiniteDuration
 
-import dev.profunktor.redis4cats.effects.{GetExArg, SetArgs}
+import dev.profunktor.redis4cats.effects.{ GetExArg, SetArgs }
 
 import io.lettuce.core.RedisFuture
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -106,6 +106,7 @@ object effects {
 
   sealed trait GetExArg
   object GetExArg {
+
     /** Set Expiration in Millis */
     case class Px(duration: FiniteDuration) extends GetExArg
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -492,14 +492,11 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     pipeline[Nothing](_ => fs).void
 
   /******************************* AutoFlush API **********************************/
-  override def enableAutoFlush: F[Unit] =
-    async.flatMap(c => FutureLift[F].delay(c.setAutoFlushCommands(true)))
+  override def enableAutoFlush: F[Unit] = conn.setAutoFlushCommands(true)
 
-  override def disableAutoFlush: F[Unit] =
-    async.flatMap(c => FutureLift[F].delay(c.setAutoFlushCommands(false)))
+  override def disableAutoFlush: F[Unit] = conn.setAutoFlushCommands(false)
 
-  override def flushCommands: F[Unit] =
-    async.flatMap(c => FutureLift[F].delay(c.flushCommands()))
+  override def flushCommands: F[Unit] = conn.flushCommands
 
   /******************************* Unsafe API **********************************/
   override def unsafe[A](f: RedisClusterAsyncCommands[K, V] => RedisFuture[A]): F[A] =

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterFromUnderlyingDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterFromUnderlyingDemo.scala
@@ -46,7 +46,6 @@ object RedisClusterFromUnderlyingDemo extends LoggerIOApp {
                            .builder()
                            .pingBeforeActivateConnection(true)
                            .autoReconnect(true)
-                           .cancelCommandsOnReconnectFailure(true)
                            .validateClusterNodeMembership(true)
                            .timeoutOptions(timeoutOptions)
                            .build()

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -265,7 +265,7 @@ trait TestScenarios { self: FunSuite =>
       _ <- redis.del("f1")
       k <- redis.set("k", "", SetArgs(SetArg.Ttl.Ex(10.seconds)))
       _ <- IO(assertEquals(k, true))
-      kTtl <-  redis.ttl("k")
+      kTtl <- redis.ttl("k")
       _ <- IO(assert(kTtl.nonEmpty))
       _ <- redis.set("k", "v", SetArgs(SetArg.Ttl.Keep))
       kv <- redis.get("k")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     val fs2        = "3.3.0"
     val log4cats   = "2.5.0"
 
-    val lettuce = "6.1.10.RELEASE"
+    val lettuce = "6.2.1.RELEASE"
     val logback = "1.4.4"
 
     val kindProjector = "0.13.2"


### PR DESCRIPTION
The flush commands on the async connection are deprecated and will be removed in Lettuce 7.x. I went with having them as private methods on `RedisConnection` and expose them via the `AutoFlush` API.  Another approach would be to make them public on `RedisConnection` and deprecate the `AutoFlush` API in `BaseRedis` although that would require a few more changes and testing 