### PR TITLE
Allow customising ClientResources

### DIFF
--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/config.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/config.scala
@@ -17,9 +17,9 @@
 package dev.profunktor.redis4cats
 
 import scala.concurrent.duration._
-
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode
 import io.lettuce.core.cluster.ClusterClientOptions
+import io.lettuce.core.resource.ClientResources
 
 object config {
 
@@ -28,22 +28,27 @@ object config {
     val shutdown: ShutdownConfig
     val topologyViewRefreshStrategy: TopologyViewRefreshStrategy
     val nodeFilter: RedisClusterNode => Boolean
+    val clientResources: Option[ClientResources]
     def withShutdown(shutdown: ShutdownConfig): Redis4CatsConfig
     def withTopologyViewRefreshStrategy(strategy: TopologyViewRefreshStrategy): Redis4CatsConfig
     def withNodeFilter(nodeFilter: RedisClusterNode => Boolean): Redis4CatsConfig
+    def withClientResources(resources: Option[ClientResources]): Redis4CatsConfig
   }
 
   object Redis4CatsConfig {
     private case class Redis4CatsConfigImpl(
         shutdown: ShutdownConfig,
         topologyViewRefreshStrategy: TopologyViewRefreshStrategy = NoRefresh,
-        nodeFilter: RedisClusterNode => Boolean = ClusterClientOptions.DEFAULT_NODE_FILTER.test
+        nodeFilter: RedisClusterNode => Boolean = ClusterClientOptions.DEFAULT_NODE_FILTER.test,
+        clientResources: Option[ClientResources] = None
     ) extends Redis4CatsConfig {
       override def withShutdown(_shutdown: ShutdownConfig): Redis4CatsConfig = copy(shutdown = _shutdown)
       override def withTopologyViewRefreshStrategy(strategy: TopologyViewRefreshStrategy): Redis4CatsConfig =
         copy(topologyViewRefreshStrategy = strategy)
       override def withNodeFilter(_nodeFilter: RedisClusterNode => Boolean): Redis4CatsConfig =
         copy(nodeFilter = _nodeFilter)
+      override def withClientResources(resources: Option[ClientResources]): Redis4CatsConfig =
+        copy(clientResources = resources)
     }
     def apply(): Redis4CatsConfig = Redis4CatsConfigImpl(ShutdownConfig())
   }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClient.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClient.scala
@@ -35,7 +35,8 @@ object RedisClient {
       config: Redis4CatsConfig
   ): (F[RedisClient], RedisClient => F[Unit]) = {
     val acquire: F[RedisClient] = FutureLift[F].delay {
-      val jClient: JRedisClient = JRedisClient.create(config.clientResources.orNull, uri.underlying)
+      val jClient: JRedisClient =
+        config.clientResources.fold(JRedisClient.create(uri.underlying))(JRedisClient.create(_, uri.underlying))
       jClient.setOptions(opts)
       new RedisClient(jClient, uri) {}
     }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClient.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClient.scala
@@ -35,7 +35,7 @@ object RedisClient {
       config: Redis4CatsConfig
   ): (F[RedisClient], RedisClient => F[Unit]) = {
     val acquire: F[RedisClient] = FutureLift[F].delay {
-      val jClient: JRedisClient = JRedisClient.create(uri.underlying)
+      val jClient: JRedisClient = JRedisClient.create(config.clientResources.orNull, uri.underlying)
       jClient.setOptions(opts)
       new RedisClient(jClient, uri) {}
     }

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClusterClient.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClusterClient.scala
@@ -47,8 +47,8 @@ object RedisClusterClient {
       Log[F].info(s"Acquire Redis Cluster client") *>
           FutureLift[F]
             .delay {
-              val javaUri = uri.map(_.underlying).asJava
-              config.clientResources.fold(JClusterClient.create(javaUri))(JClusterClient.create(_, javaUri))
+              val javaUris = uri.map(_.underlying).asJava
+              config.clientResources.fold(JClusterClient.create(javaUris))(JClusterClient.create(_, javaUris))
             }
             .flatTap(initializeClusterTopology[F](_, config.topologyViewRefreshStrategy, config.nodeFilter))
             .map(new RedisClusterClient(_) {})

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClusterClient.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClusterClient.scala
@@ -46,7 +46,7 @@ object RedisClusterClient {
     val acquire: F[RedisClusterClient] =
       Log[F].info(s"Acquire Redis Cluster client") *>
           FutureLift[F]
-            .delay(JClusterClient.create(uri.map(_.underlying).asJava))
+            .delay(JClusterClient.create(config.clientResources.orNull, uri.map(_.underlying).asJava))
             .flatTap(initializeClusterTopology[F](_, config.topologyViewRefreshStrategy, config.nodeFilter))
             .map(new RedisClusterClient(_) {})
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -165,7 +165,7 @@ object Redis {
       *
       * It will create an underlying RedisClient using the supplied client options and config
       * to establish connection with Redis. Can be used to customise advanced features like
-      * metric recording or shutdown delays via [[Redis4CatsConfig]].
+      * metric recording or shutdown delays.
       *
       * Example:
       *


### PR DESCRIPTION
Lettuce's ClientResources allows to configure a lot of interesting features like tracing or metrics, so exposing a convenient way of customising them helps users to integrate these.

Replaces #772 in a sense that it enables metrics collection without the drawbacks #772 has.