### PR TITLE
Add non-flaky read-write test for Redis Streams  

### DIFF
--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/OptimisticLockSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/OptimisticLockSpec.scala
@@ -24,10 +24,9 @@ import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.effect.Log.NoOp._
 import dev.profunktor.redis4cats.tx._
 
-class OptimisticLockSuite extends IOSuite {
+class OptimisticLockSpec extends RedisSuite {
 
-  private val redisURI    = "redis://localhost:6379"
-  private val mkRedis     = RedisClient[IO].from(redisURI)
+  private val mkRedis     = RedisClient[IO].from(redisUri)
   private val Parallelism = 10
 
   private val testKey      = "tx-lock-key"

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
@@ -64,9 +64,9 @@ abstract class Redis4CatsFunSuite(isCluster: Boolean) extends RedisSuite {
   // --- Cluster ---
 
   private lazy val redisClusterUris = List(
-    s"$redisUri:30001",
-    s"$redisUri:30002",
-    s"$redisUri:30003"
+    s"$redisHost:30001",
+    s"$redisHost:30002",
+    s"$redisHost:30003"
   ).traverse(RedisURI.make[IO](_))
 
   private def mkRedisCluster[K, V](codec: RedisCodec[K, V]): Resource[IO, RedisCommands[IO, K, V]] =

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/Redis4CatsFunSuite.scala
@@ -26,7 +26,7 @@ import dev.profunktor.redis4cats.streams.{ RedisStream, Streaming }
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.Duration
 
-abstract class Redis4CatsFunSuite(isCluster: Boolean) extends IOSuite {
+abstract class Redis4CatsFunSuite(isCluster: Boolean) extends RedisSuite {
 
   val flushAllFixture = new Fixture[Unit]("FLUSHALL") {
     def apply(): Unit = ()
@@ -38,8 +38,6 @@ abstract class Redis4CatsFunSuite(isCluster: Boolean) extends IOSuite {
   override def munitFixtures = List(flushAllFixture)
 
   override def munitFlakyOK: Boolean = true
-
-  private val redisUri = "redis://localhost"
 
   private val stringCodec = RedisCodec.Utf8
 
@@ -65,7 +63,7 @@ abstract class Redis4CatsFunSuite(isCluster: Boolean) extends IOSuite {
 
   // --- Cluster ---
 
-  lazy val redisClusterUris = List(
+  private lazy val redisClusterUris = List(
     s"$redisUri:30001",
     s"$redisUri:30002",
     s"$redisUri:30003"

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
@@ -16,9 +16,11 @@
 
 package dev.profunktor.redis4cats
 
+import cats.effect.IO
 import dev.profunktor.redis4cats.streams.data.XAddMessage
 
 import scala.concurrent.duration.DurationInt
+import scala.util.Random
 
 class RedisStreamSpec extends Redis4CatsFunSuite(false) {
 
@@ -31,7 +33,7 @@ class RedisStreamSpec extends Redis4CatsFunSuite(false) {
       read
         .concurrently(write)
         .take(1)
-        .interruptAfter(3.seconds)
+        .interruptAfter(1.seconds)
         .compile
         .lastOrError
         .map { read =>
@@ -41,4 +43,36 @@ class RedisStreamSpec extends Redis4CatsFunSuite(false) {
     }
   }
 
+  private def generateStr: String = {
+    val len = Random.nextInt(20) + 10
+    Random.alphanumeric.take(len).mkString
+  }
+
+  private def generateMsg: Map[String, String] = {
+    val size = Random.nextInt(5) + 5
+    (0 until size).map(_ => generateStr -> generateStr).toMap
+  }
+
+  test("write then read works") {
+    withRedisStream[Unit] { stream =>
+      val len  = 100
+      val msgs = List.fill(len)(generateMsg)
+
+      val streamName = "test-stream"
+      val read       = stream.read(Set(streamName), 1)
+      val write = stream.append {
+        fs2.Stream.emits(msgs).evalMap(msg => IO(XAddMessage(streamName, msg)))
+      }
+
+      write.compile.drain.flatMap { _ =>
+        read
+          .take(len.toLong)
+          .interruptAfter(10.seconds)
+          .compile
+          .toList
+          .map(_.map(readmsg => readmsg.body))
+          .map(msgsRead => assertEquals(msgsRead, msgs))
+      }
+    }
+  }
 }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamSpec.scala
@@ -62,7 +62,7 @@ class RedisStreamSpec extends Redis4CatsFunSuite(false) {
     val len  = 1000
     val msgs = List.fill(len)(generateMsg)
 
-    val read = stream.read(Set(streamName), 1, block = Some(1.millis))
+    val read = stream.read(Set(streamName), 1)
     val write = stream.append {
       fs2.Stream.emits(msgs).map(msg => XAddMessage(streamName, msg))
     }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSuite.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSuite.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2021 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats
+
+trait RedisSuite extends IOSuite {
+
+  protected val redisHost = "redis://localhost"
+
+  protected val redisPort = "6379"
+
+  protected val redisUri = "redis://localhost:6379"
+}


### PR DESCRIPTION
A small test I added, showcasing how `block = Some(not-zero)` removes flakiness (#460).