### PR TITLE
fix snapshot release config

### DIFF
--- a/project/MimaVersionPlugin.scala
+++ b/project/MimaVersionPlugin.scala
@@ -51,7 +51,7 @@ object MimaVersionPlugin extends AutoPlugin {
             },
           git.formattedShaVersion := {
             val suffix = git.makeUncommittedSignifierSuffix(
-              git.gitUncommittedChanges.value,
+              git.gitUncommittedChanges.value || isSnapshot.value,
               git.uncommittedSignifier.value
             )
 


### PR DESCRIPTION
Using Sbt-Git to set the version has the unintended consequence that snapshots are defined by having uncommited changes.
This PR adds isSnapshot setting also