### PR TITLE
Cleanup from #880

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -57,7 +57,6 @@ import io.lettuce.core.{
 }
 import org.typelevel.keypool.KeyPool
 
-import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
@@ -1354,7 +1353,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     async
       .flatMap(
         _.evalReadOnly[output.Underlying](
-          script.getBytes(StandardCharsets.UTF_8),
+          script,
           output.outputType,
           // see comment in eval above.
           Array.emptyObjectArray.asInstanceOf[Array[K with Object]]
@@ -1365,7 +1364,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def evalReadOnly(script: String, output: ScriptOutputType[V], keys: List[K]): F[output.R] =
     async.flatMap(
       _.evalReadOnly[output.Underlying](
-        script.getBytes(StandardCharsets.UTF_8),
+        script,
         output.outputType,
         // see comment in eval above.
         keys.toArray[Any].asInstanceOf[Array[K with Object]]
@@ -1375,7 +1374,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def evalReadOnly(script: String, output: ScriptOutputType[V], keys: List[K], values: List[V]): F[output.R] =
     async.flatMap(
       _.evalReadOnly[output.Underlying](
-        script.getBytes(StandardCharsets.UTF_8),
+        script,
         output.outputType,
         // see comment in eval above.
         keys.toArray[Any].asInstanceOf[Array[K with Object]],


### PR DESCRIPTION
remove getbytes call for evalreadOnly methods as the core Lettuce library as of 6.4 has provided a method that accepts a string 