### PR TITLE
Get MiMa running again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - name: "Starting up Valkey 🐳"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: "Starting up Valkey 🐳"
         run: docker compose up -d

--- a/build.sbt
+++ b/build.sbt
@@ -110,14 +110,24 @@ lazy val `redis4cats-core` = project
     libraryDependencies ++=
         pred(scalaVersion.value.startsWith("3"), t = Seq.empty, f = Seq(Libraries.reflect(scalaVersion.value)))
   )
-  .settings(isMimaEnabled := true)
+  .settings(
+    isMimaEnabled := true,
+    mimaPreviousArtifacts ~= { prev =>
+      prev.filter(artifact => VersionNumber(artifact.revision).matchesSemVer(SemanticSelector(">=1.7.1")))
+    }
+  )
   .settings(Test / parallelExecution := false)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val `redis4cats-log4cats` = project
   .in(file("modules/log4cats"))
   .settings(commonSettings: _*)
-  .settings(isMimaEnabled := true)
+  .settings(
+    isMimaEnabled := true,
+    mimaPreviousArtifacts ~= { prev =>
+      prev.filter(artifact => VersionNumber(artifact.revision).matchesSemVer(SemanticSelector(">=1.4.3")))
+    }
+  )
   .settings(libraryDependencies += Libraries.log4CatsCore)
   .settings(Test / parallelExecution := false)
   .enablePlugins(AutomateHeaderPlugin)
@@ -129,7 +139,12 @@ lazy val `redis4cats-effects` = project
   .settings(
     libraryDependencies += Libraries.keyPool
   )
-  .settings(isMimaEnabled := true)
+  .settings(
+    isMimaEnabled := true,
+    mimaPreviousArtifacts ~= { prev =>
+      prev.filter(artifact => VersionNumber(artifact.revision).matchesSemVer(SemanticSelector(">=1.7.2")))
+    }
+  )
   .settings(Test / parallelExecution := false)
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(`redis4cats-core`)
@@ -137,7 +152,12 @@ lazy val `redis4cats-effects` = project
 lazy val `redis4cats-streams` = project
   .in(file("modules/streams"))
   .settings(commonSettings: _*)
-  .settings(isMimaEnabled := true)
+  .settings(
+    isMimaEnabled := true,
+    mimaPreviousArtifacts ~= { prev =>
+      prev.filter(artifact => VersionNumber(artifact.revision).matchesSemVer(SemanticSelector(">=1.7.2")))
+    }
+  )
   .settings(libraryDependencies += Libraries.fs2Core)
   .settings(Test / parallelExecution := false)
   .enablePlugins(AutomateHeaderPlugin)


### PR DESCRIPTION
There is a step in the workflow to run MiMa, but it doesn't have any previous versions, so nothing is being checked.  The addition of new abstract methods to various algebras, along with some changes in types, means not all 1.x releases are compatible.  This PR establishes a new baseline of compatible versions:

* redis4cats-core: 1.7.1
* redis4cats-log4cats: 1.4.3
* redis4cats-effects: 1.7.2
* redis4cats-streams: 1.7.2