### PR TITLE
Add basic stream commands to base redis for streams power users

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2021 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.redis4cats.algebra
+
+import dev.profunktor.redis4cats.effects.{ MessageId, StreamMessage, XAddArgs, XRangePoint, XReadOffsets, XTrimArgs }
+
+import scala.concurrent.duration.Duration
+
+trait StreamCommands[F[_], K, V] extends StreamGetter[F, K, V] with StreamSetter[F, K, V]
+
+trait StreamGetter[F[_], K, V] {
+
+  def xRead(
+      streams: Set[XReadOffsets[K]],
+      block: Option[Duration] = None,
+      count: Option[Long] = None
+  ): F[List[StreamMessage[K, V]]]
+  def xRange(key: K, start: XRangePoint, end: XRangePoint, count: Option[Long] = None): F[List[StreamMessage[K, V]]]
+  def xRevRange(key: K, start: XRangePoint, end: XRangePoint, count: Option[Long] = None): F[List[StreamMessage[K, V]]]
+  def xLen(key: K): F[Long]
+}
+
+trait StreamSetter[F[_], K, V] {
+
+  def xAdd(key: K, body: Map[K, V], args: XAddArgs = XAddArgs()): F[MessageId]
+  def xTrim(key: K, args: XTrimArgs): F[Long]
+  def xDel(key: K, ids: String*): F[Long]
+}

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
@@ -35,6 +35,7 @@ trait RedisCommands[F[_], K, V]
     with KeyCommands[F, K]
     with HyperLogLogCommands[F, K, V]
     with BitCommands[F, K, V]
+    with StreamCommands[F, K, V]
 
 object RedisCommands {
   implicit class LiftKOps[F[_], K, V](val cmd: RedisCommands[F, K, V]) extends AnyVal {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -16,13 +16,14 @@
 
 package dev.profunktor.redis4cats
 
-import java.time.Instant
+import cats.Eq
 
+import java.time.Instant
 import io.lettuce.core.{
   GeoArgs,
-  ScriptOutputType => JScriptOutputType,
+  KeyScanArgs => JKeyScanArgs,
   ScanArgs => JScanArgs,
-  KeyScanArgs => JKeyScanArgs
+  ScriptOutputType => JScriptOutputType
 }
 
 import scala.concurrent.duration.FiniteDuration
@@ -256,4 +257,70 @@ object effects {
     case object Stream extends RedisType("stream")
   }
 
+  /*
+  Streams
+   */
+
+  final case class XTrimArgs(
+      strategy: XTrimArgs.Strategy,
+      precision: XTrimArgs.Precision = XTrimArgs.Precision.Exact
+  )
+
+  object XTrimArgs {
+    sealed trait Strategy extends Product with Serializable
+    object Strategy {
+      final case class MAXLEN(threshold: Long) extends Strategy
+      final case class MINID(id: String) extends Strategy
+    }
+
+    sealed trait Precision extends Product with Serializable
+    object Precision {
+      case object Exact extends Precision
+      final case class Approximate(limit: Option[Long] = None) extends Precision
+    }
+  }
+
+  final case class XAddArgs(
+      nomkstream: Boolean = false,
+      id: Option[String] = None,
+      xTrimArgs: Option[XTrimArgs] = None
+  )
+
+  final case class MessageId(value: String) extends AnyVal
+
+  object MessageId {
+    implicit val eq: Eq[MessageId] = Eq.by(_.value)
+  }
+
+  sealed trait XReadOffsets[K] extends Product with Serializable {
+    def key: K
+    def offset: String
+  }
+
+  object XReadOffsets {
+    case class All[K](key: K) extends XReadOffsets[K] {
+      override def offset: String = "0"
+    }
+    case class Latest[K](key: K) extends XReadOffsets[K] {
+      override def offset: String = "$"
+    }
+    case class Custom[K](key: K, offset: String) extends XReadOffsets[K]
+  }
+
+  final case class StreamMessage[K, V](id: MessageId, key: K, body: Map[K, V])
+
+  object StreamMessage {
+    implicit def eq[K: Eq, V: Eq]: Eq[StreamMessage[K, V]] = Eq.and(Eq.by(_.id), Eq.and(Eq.by(_.key), Eq.by(_.body)))
+  }
+
+  sealed abstract class XRangePoint extends Product with Serializable
+
+  object XRangePoint {
+
+    implicit val eq: Eq[XRangePoint] = Eq.fromUniversalEquals
+
+    case object Unbounded extends XRangePoint
+    final case class Inclusive(id: String) extends XRangePoint
+    final case class Exclusive(id: String) extends XRangePoint
+  }
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -459,8 +459,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   def sync: F[RedisClusterSyncCommands[K, V]] =
     if (cluster) conn.clusterSync else conn.sync.widen
 
-  /** ***************************** Keys API ************************************
-    */
+  // format: off
+  /******************************* Keys API *************************************/
+  // format: on
   override def copy(source: K, destination: K): F[Boolean] =
     async.flatMap(_.copy(source, destination).futureLift.map(x => Boolean.box(x)))
 
@@ -1606,7 +1607,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       .map(_.asScala.map(_.asScala.toMap).toList)
 
   // format: off
-  /** ***************************** HyperLoglog API **********************************/
+  /******************************* HyperLoglog API **********************************/
   // format: on
   override def pfAdd(key: K, values: V*): F[Long] =
     async.flatMap(_.pfadd(key, values: _*).futureLift.map(Long.box(_)))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisClusterSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisClusterSpec.scala
@@ -46,6 +46,8 @@ class RedisClusterSpec extends Redis4CatsFunSuite(true) with TestScenarios {
 
   test("cluster: hyperloglog api")(withRedis(hyperloglogScenario))
 
+  test("cluster: streams api")(withRedisCluster(streamsScenario))
+
   // FIXME: The Cluster impl cannot connect to a single node just yet
   //test("cluster: pipelining")(withRedisCluster(pipelineScenario))
   //test("cluster: transactions")(withRedisCluster(transactionScenario))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisSpec.scala
@@ -56,6 +56,7 @@ class RedisSpec extends Redis4CatsFunSuite(false) with TestScenarios {
 
   test("pattern channel sub")(withRedisClient(channelPatternSubScenario))
 
+  test("streams api")(withRedis(streamsScenario))
 }
 
 object LongCodec extends JRedisCodec[String, Long] with ToByteBufEncoder[String, Long] {


### PR DESCRIPTION
Add basic (non-group) stream commands to base redis for power users.
Following commits will update Streaming module to be powered by these
basic commands instead of the limited and private RawStreams class.
