### PR TITLE
Set last redis version in tests

### DIFF
--- a/redis.yml
+++ b/redis.yml
@@ -1,8 +1,9 @@
 version: "3.0"
+# See Contribution Guidelines in README. Redis 7.2.4 is the last redis version before the Valkey fork.
 services:
   SingleNodeRedis:
     restart: always
-    image: redis:7.0.10
+    image: redis:${REDIS_VERSION:-7.2.4}
     ports:
       - "6379:6379"
     environment:
@@ -11,7 +12,7 @@ services:
 
   ReplicaNode:
     restart: always
-    image: redis:7.0.10
+    image: redis:${REDIS_VERSION:-7.2.4}
     ports:
       - "6380:6379"
     command: redis-server --replicaof SingleNodeRedis 6379
@@ -22,7 +23,7 @@ services:
 
   RedisCluster:
     restart: always
-    image: grokzen/redis-cluster:7.0.10
+    image: grokzen/redis-cluster:${REDIS_VERSION:-7.2.4}
     ports:
       - "30001:30001"
       - "30002:30002"


### PR DESCRIPTION
Fixes connection api tests which failed due to client-info not being recognized
