### PR TITLE
nix: dev shell update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: profunktor
-          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: "Run tests and compile documentation 🚀"
         run: nix run .#sbt -- buildRedis4Cats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,19 +26,19 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: "Install Nix ❄️"
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31.2.0
 
       - name: "Install Cachix ❄️"
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v16
         with:
-          name: redis4cats
+          name: profunktor
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
       - name: "Run tests and compile documentation 🚀"
-        run: nix develop -c sbt 'buildRedis4Cats'
+        run: nix run .#sbt -- buildRedis4Cats
 
       - name: "Test for Binary Compatibility 📦"
-        run: nix develop -c sbt 'mimaReportBinaryIssuesIfRelevant'
+        run: nix run .#sbt mimaReportBinaryIssuesIfRelevant
 
       - name: "Shutting down Valkey 🐳"
         run: docker compose down

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -27,7 +27,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: profunktor
-          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: "Building and publishing microsite 🚧"
         run: nix run .#sbt -- publishSite

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -21,13 +21,13 @@ jobs:
           fetch-depth: 0 # fetch all branches & tags
 
       - name: "Install Nix ❄️"
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.2.0
 
       - name: "Install Cachix ❄️"
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v16
         with:
-          name: redis4cats
+          name: profunktor
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
       - name: "Building and publishing microsite 🚧"
-        run: nix develop -c sbt 'publishSite'
+        run: nix run .#sbt -- publishSite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
           fetch-depth: 0 # fetch all branches & tags
 
       - name: "Install Nix ❄️"
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.2.0
 
       - name: "Install Cachix ❄️"
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v16
         with:
-          name: redis4cats
+          name: profunktor
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
       - name: "Publish ${{ github.ref }} 🚀"
@@ -32,4 +32,4 @@ jobs:
           PGP_SECRET: "${{ secrets.PGP_SECRET }}"
           SONATYPE_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"
           SONATYPE_USERNAME: "${{ secrets.SONATYPE_USERNAME }}"
-        run: nix develop -c sbt 'ci-release'
+        run: nix run .#sbt -- ci-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: profunktor
-          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: "Publish ${{ github.ref }} 🚀"
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -20,11 +20,12 @@ promptTheme := PromptTheme(
 ThisBuild / organization := "dev.profunktor"
 ThisBuild / homepage := Some(url("https://redis4cats.profunktor.dev/"))
 ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+ThisBuild / sonatypeCredentialHost := xerial.sbt.Sonatype.sonatypeCentralHost
 ThisBuild / developers := List(
   Developer(
     "gvolpe",
     "Gabriel Volpe",
-    "volpegabriel@gmail.com",
+    "profunktor@gvolpe.addy.io",
     url("https://gvolpe.com")
   )
 )
@@ -40,7 +41,7 @@ val commonSettings = Seq(
   organizationName := "Redis client for Cats Effect & Fs2",
   startYear := Some(2018),
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
-  headerLicense := Some(HeaderLicense.ALv2("2018-2021", "ProfunKtor")),
+  headerLicense := Some(HeaderLicense.ALv2("2018-2025", "ProfunKtor")),
   testFrameworks += new TestFramework("munit.Framework"),
   libraryDependencies ++= Seq(
     Libraries.catsEffectKernel,

--- a/flake.lock
+++ b/flake.lock
@@ -20,18 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
-        "owner": "nixos",
+        "lastModified": 1745526057,
+        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,43 +2,47 @@
   description = "Scala development shell";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
+    nixpkgs.url = "nixpkgs/nixos-unstable";
     flake-utils.url = github:numtide/flake-utils;
   };
 
   outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        # Setting SBT_OPTS because of this bug: https://github.com/sbt/sbt-site/issues/169
-        sbt-overlay = self: super: {
-          sbt = super.sbt.overrideAttrs (
-            old: {
-              nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ super.makeWrapper ];
-              postInstall = ''
-                wrapProgram $out/bin/sbt --suffix SBT_OPTS : '--add-opens java.base/java.lang=ALL-UNNAMED'
-              '';
-            }
-          );
-        };
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ sbt-overlay ];
-        };
-        jdk = pkgs.jdk19_headless;
+        overlays = [
+          (self: super: {
+            jre = super.jdk21_headless;
+            sbt = super.sbt.overrideAttrs (
+              old: {
+                nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ super.makeWrapper ];
+                # Setting SBT_OPTS because of this bug: https://github.com/sbt/sbt-site/issues/169
+                postInstall = ''
+                  wrapProgram $out/bin/sbt --suffix SBT_OPTS : '--add-opens java.base/java.lang=ALL-UNNAMED'
+                '';
+              }
+            );
+          })
+        ];
+        pkgs = import nixpkgs { inherit system overlays; };
       in
       {
         devShell = pkgs.mkShell {
           name = "scala-dev-shell";
-          buildInputs = [
-            jdk
-            pkgs.gnupg
-            pkgs.jekyll
-            pkgs.sbt
+
+          buildInputs = with pkgs; [
+            gnupg
+            jekyll
+            jre
+            sbt
           ];
 
           shellHook = ''
-            JAVA_HOME="${jdk}"
+            JAVA_HOME="${pkgs.jre}"
           '';
+        };
+
+        packages = {
+          inherit (pkgs) sbt;
         };
       });
 }

--- a/modules/core/src/main/scala-2.13+/dev.profunktor.redis4cats/JavaConversions.scala
+++ b/modules/core/src/main/scala-2.13+/dev.profunktor.redis4cats/JavaConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala-2/dev/profunktor/redis4cats/TypeInqualityCompat.scala
+++ b/modules/core/src/main/scala-2/dev/profunktor/redis4cats/TypeInqualityCompat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala-2/dev/profunktor/redis4cats/syntax/RedisURIOps.scala
+++ b/modules/core/src/main/scala-2/dev/profunktor/redis4cats/syntax/RedisURIOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala-2/dev/profunktor/redis4cats/syntax/macros.scala
+++ b/modules/core/src/main/scala-2/dev/profunktor/redis4cats/syntax/macros.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/Codecs.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/Codecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/splits/SplitEpi.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/splits/SplitEpi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/splits/SplitMono.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/splits/SplitMono.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/splits/package.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/codecs/splits/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/config.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/config.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClient.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClusterClient.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisClusterClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisConnection.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisMasterReplica.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisMasterReplica.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisURI.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/connection/RedisURI.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/data.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/data.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/FutureLift.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/FutureLift.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/Log.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/Log.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/MkRedis.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/MkRedis.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/TxExecutor.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/TxExecutor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/TxThreadFactory.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/effect/TxThreadFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/tx/TxRunner.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/tx/TxRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/tx/TxStore.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/tx/TxStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/scala/dev/profunktor/redis4cats/tx/package.scala
+++ b/modules/core/src/main/scala/dev/profunktor/redis4cats/tx/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/autoflush.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/autoflush.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/bitmaps.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/bitmaps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/connection.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/connection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hyperloglog.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hyperloglog.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/keys.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/keys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/lists.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/lists.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/server.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/server.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/transaction.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/transaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/commands.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/extensions/luaScripting.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/extensions/luaScripting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/Demo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/Demo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/JsonCodecDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/JsonCodecDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/LoggerIOApp.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/LoggerIOApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PubSubDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/PublisherDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisBitmapsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisBitmapsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterFromUnderlyingDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterFromUnderlyingDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterStringsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisClusterTransactionsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisHashesDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisKeysDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisLiftKDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisLiftKDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisListsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisMasterReplicaStringsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPipelineDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPoolDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisPoolDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisScriptsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSetsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisSortedSetsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisStringsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTxDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisTxDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/StreamingDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/StreamingDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
+++ b/modules/log4cats/src/main/scala/dev/profunktor/redis4cats/log4cats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/RestartOnTimeout.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/RestartOnTimeout.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/StreamsInstances.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/StreamsInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSub.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSubCommands.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/PubSubCommands.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/data.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/data.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/LivePubSubCommands.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/LivePubSubCommands.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/LivePubSubStats.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/LivePubSubStats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubInternals.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubInternals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubState.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/PubSubState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/Publisher.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/Publisher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/Redis4CatsSubscription.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/Redis4CatsSubscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/Subscriber.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/pubsub/internals/Subscriber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/RedisStream.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/RedisStream.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/data.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/data.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
+++ b/modules/streams/src/main/scala/dev/profunktor/redis4cats/streams/streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 ProfunKtor
+ * Copyright 2018-2025 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Also update the headers year while we're at it. I'm unifying the secrets for the entire organization now that it's supported, as it simplifies everything. The new [Nix cache](https://app.cachix.org/cache/profunktor) will be shared across all the Profunktor projects as well.

```
profunktor.cachix.org-1:UnJFLHvH1uI5u9iIkqaG3DT9Sfqy4QQ1+aEiCb90Oeo=
```