### PR TITLE
Add GEOSEARCH

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
@@ -31,7 +31,7 @@ trait GeoGetter[F[_], K, V] {
   def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit): F[Set[V]]
   def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit, args: GeoArgs): F[List[GeoRadiusResult[V]]]
   def geoSearch(key: K, from: GeoSearch[V], area: GeoSearchArea): F[Set[V]]
-  def geoSearch(key: K, from: GeoSearch[V], area: GeoSearchArea, args: GeoArgs): F[List[GeoRadiusResult[V]]]
+  def geoSearch(key: K, from: GeoSearch[V], area: GeoSearchArea, args: GeoArgs): F[List[GeoSearchResult[V]]]
 }
 
 trait GeoSetter[F[_], K, V] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
@@ -30,6 +30,8 @@ trait GeoGetter[F[_], K, V] {
   def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, args: GeoArgs): F[List[GeoRadiusResult[V]]]
   def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit): F[Set[V]]
   def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit, args: GeoArgs): F[List[GeoRadiusResult[V]]]
+  def geoSearch(key: K, from: GeoSearch[V], area: GeoSearchArea): F[Set[V]]
+  def geoSearch(key: K, from: GeoSearch[V], area: GeoSearchArea, args: GeoArgs): F[List[GeoRadiusResult[V]]]
 }
 
 trait GeoSetter[F[_], K, V] {
@@ -38,4 +40,6 @@ trait GeoSetter[F[_], K, V] {
   def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, storage: GeoRadiusDistStorage[K]): F[Unit]
   def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit, storage: GeoRadiusKeyStorage[K]): F[Unit]
   def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit, storage: GeoRadiusDistStorage[K]): F[Unit]
+  def geoSearch(key: K, from: GeoSearch[V], area: GeoSearchArea, storage: GeoRadiusKeyStorage[K]): F[Unit]
+  def geoSearch(key: K, from: GeoSearch[V], area: GeoSearchArea, storage: GeoRadiusDistStorage[K]): F[Unit]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -44,6 +44,18 @@ object effects {
   final case class GeoRadiusKeyStorage[K](key: K, count: Long, sort: GeoArgs.Sort)
   final case class GeoRadiusDistStorage[K](key: K, count: Long, sort: GeoArgs.Sort)
 
+  sealed trait GeoSearch[V]
+  object GeoSearch {
+    final case class FromMember[V](member: V) extends GeoSearch[V]
+    final case class FromLonLat[V](longitude: Longitude, latitude: Latitude) extends GeoSearch[V]
+  }
+
+  sealed trait GeoSearchArea
+  object GeoSearchArea {
+    final case class ByRadius(radius: Distance, unit: GeoArgs.Unit) extends GeoSearchArea
+    final case class ByBox(width: Double, height: Double, unit: GeoArgs.Unit) extends GeoSearchArea
+  }
+
   final case class Score(value: Double) extends AnyVal
   final case class ScoreWithValue[V](score: Score, value: V)
   final case class ZRange[V](start: V, end: V)

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -41,6 +41,12 @@ object effects {
 
   final case class GeoCoordinate(x: Double, y: Double)
   final case class GeoRadiusResult[V](value: V, dist: Distance, hash: GeoHash, coordinate: GeoCoordinate)
+  final case class GeoSearchResult[V](
+      value: V,
+      dist: Option[Distance],
+      hash: Option[GeoHash],
+      coordinate: Option[GeoCoordinate]
+  )
   final case class GeoRadiusKeyStorage[K](key: K, count: Long, sort: GeoArgs.Sort)
   final case class GeoRadiusDistStorage[K](key: K, count: Long, sort: GeoArgs.Sort)
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1345,6 +1345,53 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   ): F[Unit] =
     async.flatMap(_.georadiusbymember(key, value, dist.value, unit, storage.asGeoRadiusStoreArgs).futureLift.void)
 
+  override def geoSearch(key: K, from: effects.GeoSearch[V], area: GeoSearchArea): F[Set[V]] =
+    async.flatMap(_.geosearch(key, from.asJava, area.asJava).futureLift.map(_.asScala.toSet))
+
+  override def geoSearch(
+      key: K,
+      from: effects.GeoSearch[V],
+      area: GeoSearchArea,
+      args: GeoArgs
+  ): F[List[GeoRadiusResult[V]]] =
+    async.flatMap(
+      _.geosearch(key, from.asJava, area.asJava, args).futureLift.map(_.asScala.toList.map(_.asGeoRadiusResult))
+    )
+
+  override def geoSearch(
+      key: K,
+      from: effects.GeoSearch[V],
+      area: GeoSearchArea,
+      storage: GeoRadiusKeyStorage[K]
+  ): F[Unit] =
+    async.flatMap(
+      _.geosearchstore(
+        storage.key,
+        key,
+        from.asJava,
+        area.asJava,
+        GeoArgs.Builder.count(storage.count),
+        false
+      ).futureLift.void
+    )
+
+  override def geoSearch(
+      key: K,
+      from: effects.GeoSearch[V],
+      area: GeoSearchArea,
+      storage: GeoRadiusDistStorage[K]
+  ): F[Unit] =
+    async.flatMap(
+      _.geosearchstore(
+        storage.key,
+        key,
+        from.asJava,
+        area.asJava,
+        GeoArgs.Builder.count(storage.count),
+        true
+      ).futureLift.void
+    )
+
   // format: off
   /******************************* Sorted Sets API **********************************/
   // format: on
@@ -2051,6 +2098,21 @@ private[redis4cats] trait RedisConversionOps {
         .withStoreDist[K](v.key)
         .withCount(v.count)
       store.asInstanceOf[GeoRadiusStoreArgs[K]]
+    }
+  }
+
+  private[redis4cats] implicit class GeoSearchOps[V](v: effects.GeoSearch[V]) {
+    def asJava[K]: io.lettuce.core.GeoSearch.GeoRef[K] = v match {
+      case effects.GeoSearch.FromMember(member) => io.lettuce.core.GeoSearch.fromMember(member.asInstanceOf[K])
+      case effects.GeoSearch.FromLonLat(longitude, latitude) =>
+        io.lettuce.core.GeoSearch.fromCoordinates(longitude.value, latitude.value)
+    }
+  }
+
+  private[redis4cats] implicit class GeoSearchAreaOps(v: GeoSearchArea) {
+    def asJava: io.lettuce.core.GeoSearch.GeoPredicate = v match {
+      case GeoSearchArea.ByRadius(radius, unit)     => io.lettuce.core.GeoSearch.byRadius(radius.value, unit)
+      case GeoSearchArea.ByBox(width, height, unit) => io.lettuce.core.GeoSearch.byBox(width, height, unit)
     }
   }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1353,9 +1353,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       from: effects.GeoSearch[V],
       area: GeoSearchArea,
       args: GeoArgs
-  ): F[List[GeoRadiusResult[V]]] =
+  ): F[List[GeoSearchResult[V]]] =
     async.flatMap(
-      _.geosearch(key, from.asJava, area.asJava, args).futureLift.map(_.asScala.toList.map(_.asGeoRadiusResult))
+      _.geosearch(key, from.asJava, area.asJava, args).futureLift.map(_.asScala.toList.map(_.asGeoSearchResult))
     )
 
   override def geoSearch(
@@ -2080,6 +2080,14 @@ private[redis4cats] trait RedisConversionOps {
         Distance(v.getDistance),
         GeoHash(v.getGeohash),
         GeoCoordinate(v.getCoordinates.getX.doubleValue(), v.getCoordinates.getY.doubleValue())
+      )
+
+    def asGeoSearchResult: GeoSearchResult[V] =
+      GeoSearchResult[V](
+        v.getMember,
+        Option(v.getDistance).map(Distance(_)),
+        Option(v.getGeohash).map(GeoHash(_)),
+        Option(v.getCoordinates).map(c => GeoCoordinate(c.getX.doubleValue(), c.getY.doubleValue()))
       )
   }
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -56,18 +56,22 @@ trait TestScenarios { self: FunSuite =>
       gs1 <- redis.geoSearch(
                testKey,
                GeoSearch.FromMember(_BuenosAires.value),
-               GeoSearchArea.ByRadius(Distance(500.0), GeoArgs.Unit.km)
+               GeoSearchArea.ByRadius(Distance(500.0), GeoArgs.Unit.km),
+               GeoArgs.Builder.distance()
              )
-      _ <- IO(assert(gs1.contains(_BuenosAires.value)))
-      _ <- IO(assert(gs1.contains(_Montevideo.value)))
-      _ <- IO(assert(!gs1.contains(_RioDeJaneiro.value)))
+      _ <- IO(assert(gs1.exists(_.value == _BuenosAires.value)))
+      _ <- IO(assert(gs1.exists(_.value == _Montevideo.value)))
+      _ <- IO(assert(!gs1.exists(_.value == _RioDeJaneiro.value)))
+      _ <- IO(assert(gs1.forall(_.dist.isDefined)))
       gs2 <- redis.geoSearch(
                testKey,
                GeoSearch.FromLonLat(_BuenosAires.lon, _BuenosAires.lat),
-               GeoSearchArea.ByBox(1000.0, 1000.0, GeoArgs.Unit.km)
+               GeoSearchArea.ByBox(1000.0, 1000.0, GeoArgs.Unit.km),
+               GeoArgs.Builder.count(2)
              )
-      _ <- IO(assert(gs2.contains(_BuenosAires.value)))
-      _ <- IO(assert(gs2.contains(_Montevideo.value)))
+      _ <- IO(assertEquals(gs2.size, 2))
+      _ <- IO(assert(gs2.exists(_.value == _BuenosAires.value)))
+      _ <- IO(assert(gs2.exists(_.value == _Montevideo.value)))
       _ <- redis.geoSearch(
              testKey,
              GeoSearch.FromMember(_BuenosAires.value),

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -53,6 +53,30 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assert(y.contains(GeoCoordinate(-43.17289799451828, -22.906801071586663))))
       z <- redis.geoRadius(testKey, GeoRadius(_Montevideo.lon, _Montevideo.lat, Distance(10000.0)), GeoArgs.Unit.km)
       _ <- IO(assert(z.toList.containsSlice(List(_BuenosAires.value, _Montevideo.value, _RioDeJaneiro.value))))
+      gs1 <- redis.geoSearch(
+               testKey,
+               GeoSearch.FromMember(_BuenosAires.value),
+               GeoSearchArea.ByRadius(Distance(500.0), GeoArgs.Unit.km)
+             )
+      _ <- IO(assert(gs1.contains(_BuenosAires.value)))
+      _ <- IO(assert(gs1.contains(_Montevideo.value)))
+      _ <- IO(assert(!gs1.contains(_RioDeJaneiro.value)))
+      gs2 <- redis.geoSearch(
+               testKey,
+               GeoSearch.FromLonLat(_BuenosAires.lon, _BuenosAires.lat),
+               GeoSearchArea.ByBox(1000.0, 1000.0, GeoArgs.Unit.km)
+             )
+      _ <- IO(assert(gs2.contains(_BuenosAires.value)))
+      _ <- IO(assert(gs2.contains(_Montevideo.value)))
+      _ <- redis.geoSearch(
+             testKey,
+             GeoSearch.FromMember(_BuenosAires.value),
+             GeoSearchArea.ByRadius(Distance(500.0), GeoArgs.Unit.km),
+             GeoRadiusKeyStorage("gs-store", 10, GeoArgs.Sort.asc)
+           )
+      gs3 <- redis.zRange("gs-store", 0, -1)
+      _ <- IO(assert(gs3.contains(_BuenosAires.value)))
+      _ <- IO(assert(gs3.contains(_Montevideo.value)))
     } yield ()
   }
 


### PR DESCRIPTION
Added wrappers for already existing in lettuce methods.

```scala
_.geoSearch(
  key,
  GeoSearch.FromLonLat(Longitude(0), Latitude(0)),
  GeoSearchArea.ByRadius(Distance(22000), GeoArgs.Unit.km)
)
```

```scala
_.geoSearch(
  key,
  GeoSearch.FromLonLat(Longitude(point.lon), Latitude(point.lat)),
  GeoSearchArea.ByRadius(Distance(radius), GeoArgs.Unit.m),
  GeoArgs().sort(GeoArgs.Sort.asc).withCount(limit)
).map(_.map(_.value))
```

Tried with real data in Dragonfly, works fine.