### PR TITLE
Add GETDEL command support

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -33,6 +33,7 @@ trait StringCommands[F[_], K, V]
 
 trait Getter[F[_], K, V] {
   def get(key: K): F[Option[V]]
+  def getDel(key: K): F[Option[V]]
   def getEx(key: K, getExArg: GetExArg): F[Option[V]]
   def getRange(key: K, start: Long, end: Long): F[Option[V]]
   def strLen(key: K): F[Long]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -731,6 +731,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def get(key: K): F[Option[V]] =
     async.flatMap(_.get(key).futureLift.map(Option.apply))
 
+  override def getDel(key: K): F[Option[V]] =
+    async.flatMap(_.getdel(key).futureLift.map(Option.apply))
+
   override def getEx(key: K, getExArg: GetExArg): F[Option[V]] = {
     val jgetExArgs = new JGetExArgs()
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -639,6 +639,13 @@ trait TestScenarios { self: FunSuite =>
       kttl4 <- redis.ttl("keyToExpire")
       _ <- IO(kttl4.nonEmpty)
       _ <- redis.del("keyToExpire")
+      getDelMissing <- redis.getDel("keyToGetDel")
+      _ <- IO(assert(getDelMissing.isEmpty))
+      _ <- redis.set("keyToGetDel", "valueToGetDel")
+      getDelExisting <- redis.getDel("keyToGetDel")
+      _ <- IO(assert(getDelExisting.contains("valueToGetDel")))
+      getDelAfter <- redis.get("keyToGetDel")
+      _ <- IO(assert(getDelAfter.isEmpty))
     } yield ()
   }
 


### PR DESCRIPTION
## Summary
- Adds `getDel` to the `Getter` algebra and implements it in `BaseRedis` via Lettuce's `getdel`.
- Adds an integration test in `TestScenarios.stringsScenario` covering missing key, existing key, and post-call deletion.

## Example
```scala
for {
  _    <- redis.set("key", "value")
  v    <- redis.getDel("key")    // Some("value")
  gone <- redis.get("key")       // None
} yield ()
```

## Test plan
- [ ] `sbt tests/Test/compile`
- [ ] `sbt scalafmtCheckAll`
- [ ] Integration test `stringsScenario` passes against a live Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)