### PR TITLE
docs: document ACL API, RedisURI auth/config, HyperLogLog & hash field-expiration

### DIFF
--- a/site/docs/client.md
+++ b/site/docs/client.md
@@ -109,9 +109,21 @@ val `redis-socket` = redis"redis-socket:///tmp/redis.sock"
 
 ### Authentication credentials
 
-Instead of embedding credentials in the URI string, you can attach them in a type-safe way with
-`withCredentials`. This is handy when a token contains URI-reserved characters (`@`, `:`, `/`),
-which would otherwise need escaping.
+Redis authentication — the `AUTH` performed during the connection handshake — can be supplied in three
+ways:
+
+1. **In the URI string**: `redis://:password@host` (password only) or `redis://username:password@host`
+   (an ACL user). Convenient, but a password/token containing URI-reserved characters (`@`, `:`, `/`)
+   must be percent-encoded.
+2. **Attached to a `RedisURI`** with `withCredentials` (shown below), which avoids any escaping.
+3. **As part of a `RedisUriConfig`** with `.withCredentials` (see the next section).
+
+Approaches 2 and 3 both take a `RedisCredentials`, a small sum type that mirrors the two forms of
+Redis `AUTH`:
+
+- `RedisCredentials.Password(token)` — a password/token with no username (`AUTH <token>`).
+- `RedisCredentials.UsernameAndPassword(username, token)` — a username and password, i.e. the Redis 6+
+  ACL-style `AUTH <username> <token>`, authenticating as a specific [ACL user](./effects/acl.html).
 
 ```scala
 import dev.profunktor.redis4cats.connection._
@@ -127,6 +139,11 @@ RedisURI
 
 The resulting `RedisURI` can be passed to `RedisClient[IO].fromUri(...)`, and is also accepted by the
 cluster and master/replica connections.
+
+These credentials authenticate the connection when it is established. To re-authenticate an
+already-open connection at runtime, use `auth` from the [Connection API](./effects/connection.html); to
+manage the ACL users, passwords and permissions these credentials authenticate against, see the
+[ACL API](./effects/acl.html).
 
 ### Building a RedisURI from config
 
@@ -156,6 +173,12 @@ RedisURI.fromConfig[IO](
 // Unix socket
 RedisURI.fromConfig[IO](RedisUriConfig.socket("/tmp/redis.sock"))
 ```
+
+`RedisUriConfig.withCredentials` takes the same `RedisCredentials` described under
+[Authentication credentials](#authentication-credentials) above, so `Password` and
+`UsernameAndPassword` (ACL user) behave identically here. Note that a Sentinel `SentinelNode` carries
+its own optional `withPassword` — that authenticates to the *Sentinel* node itself, independently of
+the `RedisUriConfig.credentials` used to authenticate to the Redis data node.
 
 Dynamic/rotating credentials (Lettuce's `RedisCredentialsProvider`) are not currently supported;
 use a static `RedisCredentials` or embed credentials in the URI string.

--- a/site/docs/effects/acl.md
+++ b/site/docs/effects/acl.md
@@ -1,0 +1,163 @@
+---
+layout: docs
+title:  "ACL"
+number: 16
+---
+
+# ACL API
+
+Purely functional interface for the [ACL API](https://redis.io/commands#server) (`ACL ...`), used to
+inspect and manage Redis [Access Control Lists](https://redis.io/docs/management/security/acl/) —
+users, their passwords, and the commands, keys and channels they are allowed to touch.
+
+The algebra is `AclCommands[F]` (note: it has no key/value type parameters, since ACL operates on
+usernames and rule strings rather than your codec's `K`/`V`). It is the union of two smaller algebras:
+`AclManagement[F]` (server-wide: `WHOAMI`, `CAT`, `GENPASS`, `LIST`, `LOAD`, `SAVE`, `LOG`) and
+`AclUserManagement[F]` (per-user: `USERS`, `GETUSER`, `SETUSER`, `DELUSER`).
+
+```scala mdoc:invisible
+import cats.effect.{IO, Resource}
+import cats.implicits._
+import dev.profunktor.redis4cats.Redis
+import dev.profunktor.redis4cats.algebra.AclCommands
+import dev.profunktor.redis4cats.data._
+import dev.profunktor.redis4cats.log4cats._
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+val commandsApi: Resource[IO, AclCommands[IO]] = {
+  Redis[IO].fromClient[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[AclCommands[IO]]
+}
+```
+
+### ACL Commands usage
+
+Once you have acquired a connection you can start using it:
+
+```scala mdoc:silent
+import dev.profunktor.redis4cats.effects.{ AclCategory, RawCommand }
+import dev.profunktor.redis4cats.effects.AclSetUserRule._
+
+commandsApi.use { redis => // AclCommands[IO]
+  for {
+    _     <- redis.aclWhoAmI                // the current connection's user, e.g. "default"
+    _     <- redis.aclCat                   // Set[AclCategory] — the available categories
+    _     <- redis.aclCat(AclCategory.Read) // Set[String] — command names in the "read" category
+    _     <- redis.aclSetUser(
+               "alice",
+               List(
+                 On,
+                 AddPassword("s3cret"),
+                 NoCommands,
+                 AddCommand(RawCommand("get")),
+                 AddCategory(AclCategory.Read),
+                 KeyPattern("app:*"),
+                 ChannelPattern("news.*")
+               )
+             )
+    _     <- redis.aclUsers                 // List[String] — all configured usernames
+    alice <- redis.aclGetUser("alice")      // Option[AclUser]
+    _     <- redis.aclDelUser("alice")      // Long — number of users actually deleted
+  } yield alice
+}
+```
+
+### Creating and modifying users with `SETUSER`
+
+`aclSetUser` takes the username and an **ordered** `List[AclSetUserRule]`; the rules are applied in
+order, exactly like the arguments to the `ACL SETUSER` command. The rule type is a closed sum type, so
+illegal combinations are caught at compile time rather than as a runtime error from Redis:
+
+| Rule | `ACL SETUSER` equivalent |
+| --- | --- |
+| `On` / `Off` | `on` / `off` |
+| `Reset` | `reset` |
+| `AddPassword(p)` / `RemovePassword(p)` | `>p` / `<p` |
+| `AddHashedPassword(h)` / `RemoveHashedPassword(h)` | `#h` / `!h` |
+| `NoPass` / `ResetPass` | `nopass` / `resetpass` |
+| `AllKeys` / `ResetKeys` / `KeyPattern(p)` | `allkeys` (`~*`) / `resetkeys` / `~p` |
+| `AllChannels` / `ResetChannels` / `ChannelPattern(p)` | `allchannels` (`&*`) / `resetchannels` / `&p` |
+| `AllCommands` / `NoCommands` | `allcommands` (`+@all`) / `nocommands` (`-@all`) |
+| `AddCommand(c)` / `RemoveCommand(c)` | `+c` / `-c` |
+| `AddCategory(cat)` / `RemoveCategory(cat)` | `+@cat` / `-@cat` |
+
+A few notes on the typed arguments:
+
+- **`KeyPattern`/`ChannelPattern`** take the bare glob (e.g. `"app:*"`, `"news.*"`); the `~`/`&`
+  prefix is added for you.
+- **`AddCategory`/`RemoveCategory`** take an `AclCategory` — a sealed enumeration of the categories
+  Redis understands (`AclCategory.Read`, `AclCategory.Write`, `AclCategory.Dangerous`, …), so a typo
+  cannot compile.
+- **`AddCommand`/`RemoveCommand`** take a `RawCommand(name)`. The set of Redis commands is open
+  (modules and new versions add commands), so it is modelled as a string newtype rather than a closed
+  enum. A name the driver does not recognise fails with `AclError.UnknownCommand` when the rule is
+  applied — it never throws.
+
+### Reading a user with `GETUSER`
+
+`aclGetUser` returns `Option[AclUser]`. `None` means **the user does not exist** — and only that;
+a malformed reply fails instead (see *Errors* below). `AclUser` mirrors the fields Redis reports:
+
+```scala
+final case class AclUser(
+    flags: List[String],     // e.g. List("on", "nopass")
+    passwords: List[String], // SHA-256 hashes of the user's passwords
+    commands: String,        // the command rule string, e.g. "-@all +get +@read"
+    keys: String,            // the key rule string, e.g. "~app:*"
+    channels: String,        // the channel rule string, e.g. "&news.*"
+    selectors: List[AclSelector]
+)
+
+// Redis 7+ selectors, each its own commands/keys/channels rule strings
+final case class AclSelector(commands: String, keys: String, channels: String)
+```
+
+The `commands`/`keys`/`channels` fields are the rule strings exactly as Redis renders them (so the
+`~`/`&`/`+`/`-` prefixes are present here, on the way *out* — unlike the bare patterns you pass *in*).
+
+### Categories and commands
+
+`aclCat` returns the set of available categories as `AclCategory` values; `aclCat(category)` returns the
+command names (lowercase) that belong to a category:
+
+```scala mdoc:silent
+commandsApi.use { redis =>
+  for {
+    categories <- redis.aclCat               // Set[AclCategory]
+    readCmds   <- redis.aclCat(AclCategory.Read) // Set[String], e.g. contains "get"
+  } yield (categories, readCmds)
+}
+```
+
+### The ACL log
+
+`aclLog` returns recent ACL security events (auth failures, denied commands/keys/channels) as
+field/value maps; `aclLogReset` clears it:
+
+```scala mdoc:silent
+commandsApi.use { redis =>
+  redis.aclLogReset >> redis.aclLog // List[Map[String, String]]
+}
+```
+
+### Errors
+
+ACL failures surface as `AclError` (a `Throwable`, raised into `F`), never as thrown exceptions from
+argument building or silent coercions:
+
+- `AclError.UnknownCommand(name)` — a `RawCommand` passed to `SETUSER` is not known to the driver.
+- `AclError.DecodingFailure(msg)` — an `ACL GETUSER`/`ACL LOG` reply could not be decoded into the
+  expected shape.
+
+Because `aclGetUser`/`aclLog` decode replies as UTF-8 text, they assume the connection uses a
+string-decoding codec. On a connection whose value codec produces non-string values (e.g.
+`Array[Byte]`), these two commands fail with an `AclError.DecodingFailure` rather than returning a
+partial result.
+
+### See also
+
+For supplying credentials when *connecting* (as opposed to managing users on the server), see
+[Authentication](../client.html#authentication-credentials) on the Client page — in particular
+`RedisCredentials.UsernameAndPassword`, which authenticates as a Redis 6+ ACL user.

--- a/site/docs/effects/hashes.md
+++ b/site/docs/effects/hashes.md
@@ -56,3 +56,39 @@ commandsApi.use { redis => // HashCommands[IO, String, String]
   } yield ()
 }
 ```
+
+### Field expiration (`HEXPIRE`) and read-and-modify (`HGETEX`/`HGETDEL`)
+
+Redis 7.4+ supports per-**field** TTLs and atomic read-and-modify reads. Each of these commands acts
+on one or more fields and returns one result per field, in the order given.
+
+```scala mdoc:silent
+import scala.concurrent.duration._
+import java.time.Instant
+import dev.profunktor.redis4cats.effects.{ ExpireExistenceArg, HGetExArgs }
+
+commandsApi.use { redis =>
+  for {
+    _ <- redis.hSet(testKey, Map("f1" -> "v1", "f2" -> "v2"))
+    // Set a relative TTL on specific fields (HEXPIRE); one status code per field.
+    _ <- redis.hExpire(testKey, 30.seconds, "f1", "f2")
+    // Conditional variant — only set the TTL if the field currently has none.
+    _ <- redis.hExpire(testKey, 1.minute, ExpireExistenceArg.Nx, "f1")
+    // Absolute expiry (HEXPIREAT).
+    _ <- redis.hExpireAt(testKey, Instant.now.plusSeconds(60), "f2")
+    // Inspect remaining TTL / absolute expiry time per field (None = no TTL or no such field).
+    _ <- redis.httl(testKey, "f1", "f2")  // List[Option[FiniteDuration]]
+    _ <- redis.hExpireTime(testKey, "f1") // List[Option[Instant]]
+    // Remove the TTL again (HPERSIST); one Boolean per field.
+    _ <- redis.hPersist(testKey, "f1")
+    // Read and (re)set expiry in one step (HGETEX), and read-and-delete (HGETDEL).
+    _ <- redis.hGetEx(testKey, HGetExArgs.Ex(10.seconds), "f1", "f2") // List[Option[String]]
+    _ <- redis.hGetDel(testKey, "f2")                                 // List[Option[String]]
+  } yield ()
+}
+```
+
+`HGetExArgs` selects what `hGetEx` does to each field's TTL while reading it (`Ex`/`Px` relative,
+`ExAt`/`PxAt` absolute, or `Persist` to clear it); `ExpireExistenceArg` (`Nx`/`Xx`/`Gt`/`Lt`) guards
+the `hExpire`/`hExpireAt` update. Millisecond-precision variants `hpttl` and `hpExpireTime` mirror
+`httl` and `hExpireTime`.

--- a/site/docs/effects/hyperloglog.md
+++ b/site/docs/effects/hyperloglog.md
@@ -1,0 +1,46 @@
+---
+layout: docs
+title:  "HyperLogLog"
+number: 17
+---
+
+# HyperLogLog API
+
+Purely functional interface for the [HyperLogLog API](https://redis.io/commands#hyperloglog), a
+probabilistic data structure for estimating the cardinality of a set using a small, fixed amount of
+memory.
+
+```scala mdoc:invisible
+import cats.effect.{IO, Resource}
+import cats.implicits._
+import dev.profunktor.redis4cats.Redis
+import dev.profunktor.redis4cats.algebra.HyperLogLogCommands
+import dev.profunktor.redis4cats.data._
+import dev.profunktor.redis4cats.log4cats._
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+val commandsApi: Resource[IO, HyperLogLogCommands[IO, String, String]] = {
+  Redis[IO].fromClient[String, String](null, null.asInstanceOf[RedisCodec[String, String]]).widen[HyperLogLogCommands[IO, String, String]]
+}
+```
+
+### HyperLogLog Commands usage
+
+Once you have acquired a connection you can start using it:
+
+```scala mdoc:silent
+commandsApi.use { redis => // HyperLogLogCommands[IO, String, String]
+  for {
+    _     <- redis.pfAdd("visitors", "alice", "bob", "alice") // PFADD — duplicates are ignored
+    count <- redis.pfCount("visitors")                        // PFCOUNT — approximate cardinality (~2)
+    _     <- redis.pfAdd("today", "carol")
+    _     <- redis.pfMerge("all-visitors", "visitors", "today") // PFMERGE — union into a new key
+  } yield count
+}
+```
+
+`pfCount` returns an estimate (with a standard error of ~0.81%), not an exact count — that is the
+trade-off that lets a HyperLogLog track huge sets in a constant ~12 KB.

--- a/site/docs/effects/index.md
+++ b/site/docs/effects/index.md
@@ -9,6 +9,7 @@ position: 4
 
 The API that operates at the effect level `F[_]` on top of `cats-effect`.
 
+- **[ACL API](./acl.html)**
 - **[Bitmaps API](./bitmaps.html)**
 - **[Connection API](./connection.html)**
 - **[Geo API](./geo.html)**

--- a/site/docs/effects/index.md
+++ b/site/docs/effects/index.md
@@ -14,6 +14,7 @@ The API that operates at the effect level `F[_]` on top of `cats-effect`.
 - **[Connection API](./connection.html)**
 - **[Geo API](./geo.html)**
 - **[Hashes API](./hashes.html)**
+- **[HyperLogLog API](./hyperloglog.html)**
 - **[JSON API](./json.html)**
 - **[Keys API](./keys.html)**
 - **[Lists API](./lists.html)**


### PR DESCRIPTION
## What

Documentation-only follow-up to the recently merged ACL (#1144) and `RedisUriConfig` (#1143) work, plus a sweep that closed two adjacent gaps found along the way.

### ACL
- New `site/docs/effects/acl.md` covering the `AclCommands` algebra: usage, the typed `SETUSER` rules (`AclSetUserRule` / `AclCategory` / `RawCommand`) with a rule → `ACL SETUSER` mapping table, the `AclUser`/`AclSelector` `GETUSER` result and its `Option`/absence semantics, `ACL CAT`, the ACL log, and `AclError` (`UnknownCommand` / `DecodingFailure`) + the string-codec note.
- Listed in the effects API index.

### RedisURI authentication & config
- Reworked the Client page's authentication section to make the **URI-config ↔ auth** relationship explicit: the three ways to supply credentials, the `RedisCredentials` sum type (`Password` vs `UsernameAndPassword` = ACL user), how `RedisUriConfig.withCredentials` ties in, sentinel per-node passwords, and connection-time vs runtime (`Connection API` `auth`) authentication — cross-linked to the ACL page.

### Other gaps closed
- New `site/docs/effects/hyperloglog.md` (`PFADD`/`PFCOUNT`/`PFMERGE`) + index entry — the algebra previously had no page.
- Documented the Redis 7.4+ per-field expiration and read-and-modify hash commands in `hashes.md`: `hExpire`/`hExpireAt` (+ `ExpireExistenceArg`), `httl`/`hpttl`, `hExpireTime`/`hpExpireTime`, `hPersist`, `hGetEx` (`HGetExArgs`) and `hGetDel`.

## Verification
- `sbt microsite/mdoc` — **0 errors**; all new `scala mdoc` blocks type-check against the effects module.
- Remaining `mdoc` warnings are the repo's pre-existing `.html`-link / unused-binder style warnings, uniform with every existing doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)