### PR TITLE
series/3.x: bump lettuce-core to 7.7.0.RELEASE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,11 @@ val commonSettings = Seq(
   ),
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
   scalacOptions += "-source:3.0-migration",
+  // Lettuce 7.7.0 deprecated several async command methods in favor of newer equivalents
+  // (SetArgs, LMOVE, GEOSEARCH, etc.) purely as an API preference; the old ones remain fully
+  // functional. Migrating call sites is a real API-surface change, tracked separately from
+  // this dependency bump.
+  scalacOptions += "-Wconf:cat=deprecation&origin=io\\.lettuce\\..*:s",
   Compile / doc / sources := (Compile / doc / sources).value,
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits"),
   autoAPIMappings := true,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val log4cats   = "2.8.0"
     val keyPool    = "0.4.11"
 
-    val lettuce = "7.6.0.RELEASE"
+    val lettuce = "7.7.0.RELEASE"
 
     val logback = "1.6.3"
 


### PR DESCRIPTION
## Summary

Last step before cutting 3.0.0 (sync2 #1176 → scala3-only #1177 → **this PR** → 3.0.0).

Bumps `lettuce-core` 7.6.0.RELEASE → 7.7.0.RELEASE. Release notes:
new commands (probabilistic data structures, HIMPORT, LMOVEM/BLMOVEM,
SUNIONCARD/SDIFFCARD, etc.) and bug fixes — no breaking API changes
that affect our usage.

Lettuce did deprecate several async command methods we call (`getset`,
`setnx`, `psetex`, `setex`, `hmset`, `brpoplpush`, `rpoplpush`,
`georadius`, `georadiusbymember`) in favor of newer preferred
equivalents (`SetArgs`, `LMOVE`, `GEOSEARCH`, etc.) — they remain
fully functional against Redis 8.x, this is an API-preference
deprecation, not a removal. Rather than bundle a call-site migration
(a real, separate API-surface change) into a routine version bump,
this adds a scoped `-Wconf` rule so `-Werror` doesn't fail the build
on Lettuce-originated deprecations specifically; our own code's
deprecation warnings stay fatal as before.

Not a full-history rebase of the old, long-stale scala-steward PR
(#1172, closed) — that PR predates the sync2/scala3-only work and had
accumulated the entire old series/2.x history; this is a fresh,
minimal, single-purpose branch off the current series/3.x.

## Test plan

- [x] `sbt compile` + `Test/compile` across all modules — clean, zero warnings
- [x] `sbt mimaReportBinaryIssuesIfRelevant` — no-op (no previous 3.0.0 artifacts published yet)
- [ ] CI integration tests against real Redis (can't run locally here — ports already in use by unrelated local containers)