### PR TITLE
series/3.x: migrate off Lettuce 7.7.0-deprecated command methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,10 +52,13 @@ val commonSettings = Seq(
   ),
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
   scalacOptions += "-source:3.0-migration",
-  // Lettuce 7.7.0 deprecated several async command methods in favor of newer equivalents
-  // (SetArgs, LMOVE, GEOSEARCH, etc.) purely as an API preference; the old ones remain fully
-  // functional. Migrating call sites is a real API-surface change, tracked separately from
-  // this dependency bump.
+  // Lettuce 7.7.0 deprecated most async command methods this library calls in favor of newer
+  // equivalents (SetArgs, LMOVE, GEOSEARCH); those call sites have been migrated. georadiusbymember
+  // stays on the deprecated API deliberately: its geosearch/GeoSearch.fromMember replacement is
+  // mistyped upstream (Lettuce's own source marks it "TODO: Should be V") and encodes the member
+  // with the key codec instead of the value codec, which would miscode data for a RedisCodec[K, V]
+  // with distinct K/V types. This rule silences Lettuce-originated deprecations generally so future
+  // Lettuce bumps don't fail the build on them without a deliberate look.
   scalacOptions += "-Wconf:cat=deprecation&origin=io\\.lettuce\\..*:s",
   Compile / doc / sources := (Compile / doc / sources).value,
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits"),

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -47,9 +47,11 @@ import io.lettuce.core.{
   FunctionRestoreMode => JFunctionRestoreMode,
   GeoArgs,
   GeoRadiusStoreArgs,
+  GeoSearch,
   GeoWithin,
   GetExArgs => JGetExArgs,
   HGetExArgs => JHGetExArgs,
+  LMoveArgs,
   Limit => JLimit,
   Range => JRange,
   ReadFrom => JReadFrom,
@@ -680,7 +682,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     async.flatMap(_.append(key, value).futureLift.void)
 
   override def getSet(key: K, value: V): F[Option[V]] =
-    async.flatMap(_.getset(key, value).futureLift.map(Option.apply))
+    async.flatMap(_.setGet(key, value).futureLift.map(Option.apply))
 
   override def set(key: K, value: V): F[Unit] =
     async.flatMap(_.set(key, value).futureLift.void)
@@ -703,14 +705,14 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   }
 
   override def setNx(key: K, value: V): F[Boolean] =
-    async.flatMap(_.setnx(key, value).futureLift.map(x => Boolean.box(x)))
+    async.flatMap(_.set(key, value, new JSetArgs().nx()).futureLift.map(_.isSuccess))
 
   override def setEx(key: K, value: V, expiresIn: FiniteDuration): F[Unit] =
     expiresIn.unit match {
       case TimeUnit.MILLISECONDS | TimeUnit.MICROSECONDS | TimeUnit.NANOSECONDS =>
-        async.flatMap(_.psetex(key, expiresIn.toMillis, value).futureLift.void)
+        async.flatMap(_.set(key, value, new JSetArgs().px(expiresIn.toMillis)).futureLift.void)
       case _ =>
-        async.flatMap(_.setex(key, expiresIn.toSeconds, value).futureLift.void)
+        async.flatMap(_.set(key, value, new JSetArgs().ex(expiresIn.toSeconds)).futureLift.void)
     }
 
   override def setRange(key: K, value: V, offset: Long): F[Unit] =
@@ -1066,7 +1068,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     async.flatMap(_.hsetnx(key, field, value).futureLift.map(x => Boolean.box(x)))
 
   override def hmSet(key: K, fieldValues: Map[K, V]): F[Unit] =
-    async.flatMap(_.hmset(key, fieldValues.asJava).futureLift.void)
+    async.flatMap(_.hset(key, fieldValues.asJava).futureLift.void)
 
   override def hIncrBy(key: K, field: K, amount: Long): F[Long] =
     async.flatMap(_.hincrby(key, field, amount).futureLift.map(x => Long.box(x)))
@@ -1163,7 +1165,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       .map(Option(_).map(kv => kv.getKey -> kv.getValue))
 
   override def brPopLPush(timeout: Duration, source: K, destination: K): F[Option[V]] =
-    async.flatMap(_.brpoplpush(timeout.toSecondsOrZero, source, destination).futureLift.map(Option.apply))
+    async.flatMap(
+      _.blmove(source, destination, LMoveArgs.Builder.rightLeft(), timeout.toSecondsOrZero).futureLift.map(Option.apply)
+    )
 
   override def lPop(key: K): F[Option[V]] =
     async.flatMap(_.lpop(key).futureLift.map(Option.apply))
@@ -1178,7 +1182,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     async.flatMap(_.rpop(key).futureLift.map(Option.apply))
 
   override def rPopLPush(source: K, destination: K): F[Option[V]] =
-    async.flatMap(_.rpoplpush(source, destination).futureLift.map(Option.apply))
+    async.flatMap(_.lmove(source, destination, LMoveArgs.Builder.rightLeft()).futureLift.map(Option.apply))
 
   override def rPush(key: K, values: V*): F[Long] =
     async.flatMap(_.rpush(key, values: _*).futureLift.map(x => Long.box(x)))
@@ -1282,14 +1286,32 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit): F[Set[V]] =
     async
-      .flatMap(_.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit).futureLift)
+      .flatMap(
+        _.geosearch(
+          key,
+          GeoSearch.fromCoordinates(geoRadius.lon.value, geoRadius.lat.value),
+          GeoSearch.byRadius(geoRadius.dist.value, unit)
+        ).futureLift
+      )
       .map(_.asScala.toSet)
 
   override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, args: GeoArgs): F[List[GeoRadiusResult[V]]] =
     async
-      .flatMap(_.georadius(key, geoRadius.lon.value, geoRadius.lat.value, geoRadius.dist.value, unit, args).futureLift)
+      .flatMap(
+        _.geosearch(
+          key,
+          GeoSearch.fromCoordinates(geoRadius.lon.value, geoRadius.lat.value),
+          GeoSearch.byRadius(geoRadius.dist.value, unit),
+          args
+        ).futureLift
+      )
       .map(_.asScala.toList.map(_.asGeoRadiusResult))
 
+  // georadiusbymember stays on the deprecated Lettuce API rather than geosearch/GeoSearch.fromMember:
+  // fromMember is typed `[K](member: K)` in Lettuce (a known upstream bug, marked "TODO: Should be
+  // V" in Lettuce's own source) and its build() encodes the member with the *key* codec via
+  // addKey(), not the value codec. For a RedisCodec[K, V] where K and V differ, that would silently
+  // miscode the member on the wire. georadiusbymember correctly takes the member as V.
   override def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit): F[Set[V]] =
     async.flatMap(_.georadiusbymember(key, value, dist.value, unit).futureLift.map(_.asScala.toSet))
 
@@ -1311,25 +1333,25 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, storage: GeoRadiusKeyStorage[K]): F[Unit] =
     conn.async.flatMap {
-      _.georadius(
+      _.geosearchstore(
+        storage.key,
         key,
-        geoRadius.lon.value,
-        geoRadius.lat.value,
-        geoRadius.dist.value,
-        unit,
-        storage.asGeoRadiusStoreArgs
+        GeoSearch.fromCoordinates(geoRadius.lon.value, geoRadius.lat.value),
+        GeoSearch.byRadius(geoRadius.dist.value, unit),
+        storage.asGeoArgs,
+        false
       ).futureLift.void
     }
 
   override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, storage: GeoRadiusDistStorage[K]): F[Unit] =
     conn.async.flatMap {
-      _.georadius(
+      _.geosearchstore(
+        storage.key,
         key,
-        geoRadius.lon.value,
-        geoRadius.lat.value,
-        geoRadius.dist.value,
-        unit,
-        storage.asGeoRadiusStoreArgs
+        GeoSearch.fromCoordinates(geoRadius.lon.value, geoRadius.lat.value),
+        GeoSearch.byRadius(geoRadius.dist.value, unit),
+        storage.asGeoArgs,
+        true
       ).futureLift.void
     }
 
@@ -2212,6 +2234,8 @@ private[redis4cats] trait RedisConversionOps {
   }
 
   private[redis4cats] implicit class GeoRadiusKeyStorageOps[K](v: GeoRadiusKeyStorage[K]) {
+    def asGeoArgs: GeoArgs = new GeoArgs().withCount(v.count).sort(v.sort)
+
     def asGeoRadiusStoreArgs: GeoRadiusStoreArgs[K] = {
       val store: GeoRadiusStoreArgs[_] = GeoRadiusStoreArgs.Builder
         .store[K](v.key)
@@ -2221,6 +2245,8 @@ private[redis4cats] trait RedisConversionOps {
   }
 
   private[redis4cats] implicit class GeoRadiusDistStorageOps[K](v: GeoRadiusDistStorage[K]) {
+    def asGeoArgs: GeoArgs = new GeoArgs().withCount(v.count).sort(v.sort)
+
     def asGeoRadiusStoreArgs: GeoRadiusStoreArgs[K] = {
       val store: GeoRadiusStoreArgs[_] = GeoRadiusStoreArgs.Builder
         .withStoreDist[K](v.key)


### PR DESCRIPTION
## Summary

Stacked on #1178 (bumps to lettuce-core 7.7.0, which introduced these
deprecations and added a scoped `-Wconf` rule as a stopgap). This is
the follow-up call-site migration that PR deferred.

Migrated (internal implementation only — public redis4cats signatures
unchanged):
- `getset` → `setGet`
- `setnx` → `set(key, value, SetArgs.nx())`
- `setex`/`psetex` → `set(key, value, SetArgs.ex()/.px())`
- `hmset` → `hset(key, Map)`
- `rpoplpush`/`brpoplpush` → `lmove`/`blmove(LMoveArgs.Builder.rightLeft())`
- `georadius` (coordinate-based, plain + `GeoArgs` + both storage
  overloads) → `geosearch`/`geosearchstore` with `GeoSearch.fromCoordinates`

**Deliberately NOT migrated:** `georadiusbymember` (member-based, all 4
overloads). Its `geosearch`/`GeoSearch.fromMember` replacement is
mistyped upstream — Lettuce's own source has the reference member
parameter as `[K](member: K)` with a `// TODO: Should be V` comment,
and `FromMember.build()` calls `args.addKey((K) member)`, encoding the
member with the **key** codec rather than the **value** codec. For a
`RedisCodec[K, V]` where K and V differ, that would silently miscode
the member on the wire — a real correctness bug, not just a
deprecation warning. `georadiusbymember` correctly takes the member as
`V`, so it stays as-is; narrowed the `-Wconf` comment in `build.sbt`
to explain why it's still there.

**Side effect:** `GeoRadiusKeyStorage`/`GeoRadiusDistStorage`'s `sort`
field was tracked in the case class but never actually applied by the
old `GeoRadiusStoreArgs`-based implementation (it only used `count`).
The new `geosearchstore`-based path applies both `count` and `sort` via
`GeoArgs`, so `sort` now actually takes effect for the migrated
(coordinate-based) storage calls.

## Test plan

- [x] `sbt compile` + `Test/compile` across all modules — clean, zero warnings (previously 15 deprecation warnings, all gone except the deliberately-kept `georadiusbymember`)
- [x] `sbt mimaReportBinaryIssuesIfRelevant` — no-op (no previous 3.0.0 artifacts published yet)
- [ ] CI integration tests against real Redis — will confirm once CI runs