### PR TITLE
series/3.x: redesign Geo/List/Hash APIs, fix discarded return values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ tq:q
 .bloop
 .bsp
 .envrc
+docs/superpowers/

--- a/build.sbt
+++ b/build.sbt
@@ -52,14 +52,6 @@ val commonSettings = Seq(
   ),
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
   scalacOptions += "-source:3.0-migration",
-  // Lettuce 7.7.0 deprecated most async command methods this library calls in favor of newer
-  // equivalents (SetArgs, LMOVE, GEOSEARCH); those call sites have been migrated. georadiusbymember
-  // stays on the deprecated API deliberately: its geosearch/GeoSearch.fromMember replacement is
-  // mistyped upstream (Lettuce's own source marks it "TODO: Should be V") and encodes the member
-  // with the key codec instead of the value codec, which would miscode data for a RedisCodec[K, V]
-  // with distinct K/V types. This rule silences Lettuce-originated deprecations generally so future
-  // Lettuce bumps don't fail the build on them without a deliberate look.
-  scalacOptions += "-Wconf:cat=deprecation&origin=io\\.lettuce\\..*:s",
   Compile / doc / sources := (Compile / doc / sources).value,
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits"),
   autoAPIMappings := true,

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/bitmaps.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/bitmaps.scala
@@ -47,13 +47,13 @@ trait BitCommands[F[_], K, V] {
 
   def bitField(key: K, operations: BitCommandOperation*): F[List[Long]]
 
-  def bitOpAnd(destination: K, source: K, sources: K*): F[Unit]
+  def bitOpAnd(destination: K, source: K, sources: K*): F[Long]
 
-  def bitOpNot(destination: K, source: K): F[Unit]
+  def bitOpNot(destination: K, source: K): F[Long]
 
-  def bitOpOr(destination: K, source: K, sources: K*): F[Unit]
+  def bitOpOr(destination: K, source: K, sources: K*): F[Long]
 
-  def bitOpXor(destination: K, source: K, sources: K*): F[Unit]
+  def bitOpXor(destination: K, source: K, sources: K*): F[Long]
 
   def bitPos(key: K, state: Boolean): F[Long]
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
@@ -24,18 +24,14 @@ trait GeoCommands[F[_], K, V] extends GeoGetter[F, K, V] with GeoSetter[F, K, V]
 
 trait GeoGetter[F[_], K, V] {
   def geoDist(key: K, from: V, to: V, unit: GeoArgs.Unit): F[Double]
-  def geoHash(key: K, value:V, values: V*): F[List[Option[String]]]
-  def geoPos(key: K, value:V,  values: V*): F[List[GeoCoordinate]]
-  def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit): F[Set[V]]
-  def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, args: GeoArgs): F[List[GeoRadiusResult[V]]]
-  def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit): F[Set[V]]
-  def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit, args: GeoArgs): F[List[GeoRadiusResult[V]]]
+  def geoHash(key: K, value: V, values: V*): F[List[Option[String]]]
+  def geoPos(key: K, value: V, values: V*): F[List[GeoCoordinate]]
+  def geoSearch(key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate): F[Set[V]]
+  def geoSearch(key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, args: GeoArgs): F[List[GeoRadiusResult[V]]]
 }
 
 trait GeoSetter[F[_], K, V] {
-  def geoAdd(key: K, geoValues: GeoLocation[V]*): F[Unit]
-  def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, storage: GeoRadiusKeyStorage[K]): F[Unit]
-  def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, storage: GeoRadiusDistStorage[K]): F[Unit]
-  def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit, storage: GeoRadiusKeyStorage[K]): F[Unit]
-  def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit, storage: GeoRadiusDistStorage[K]): F[Unit]
+  def geoAdd(key: K, geoValues: GeoLocation[V]*): F[Long]
+  def geoSearchStore(destination: K, key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, storeDist: Boolean): F[Long]
+  def geoSearchStore(destination: K, key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, storeDist: Boolean, args: GeoArgs): F[Long]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
@@ -32,6 +32,12 @@ trait GeoGetter[F[_], K, V] {
 
 trait GeoSetter[F[_], K, V] {
   def geoAdd(key: K, geoValues: GeoLocation[V]*): F[Long]
+  /** Issues GEOSEARCHSTORE, which only ever accepts COUNT/ASC/DESC/STOREDIST — see the
+    * `args`-taking overload below for the caveat about which `GeoArgs` flags are safe there.
+    */
   def geoSearchStore(destination: K, key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, storeDist: Boolean): F[Long]
+  /** @param args Only `count`/`sort` (i.e. COUNT/ASC/DESC) are meaningful here — GEOSEARCHSTORE
+    *             rejects the WITHDIST/WITHHASH/WITHCOORD flags that GeoArgs can also carry.
+    */
   def geoSearchStore(destination: K, key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, storeDist: Boolean, args: GeoArgs): F[Long]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/geo.scala
@@ -27,17 +27,18 @@ trait GeoGetter[F[_], K, V] {
   def geoHash(key: K, value: V, values: V*): F[List[Option[String]]]
   def geoPos(key: K, value: V, values: V*): F[List[GeoCoordinate]]
   def geoSearch(key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate): F[Set[V]]
-  def geoSearch(key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, args: GeoArgs): F[List[GeoRadiusResult[V]]]
+  def geoSearch(key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, args: GeoArgs): F[List[GeoSearchResult[V]]]
 }
 
 trait GeoSetter[F[_], K, V] {
   def geoAdd(key: K, geoValues: GeoLocation[V]*): F[Long]
-  /** Issues GEOSEARCHSTORE, which only ever accepts COUNT/ASC/DESC/STOREDIST — see the
-    * `args`-taking overload below for the caveat about which `GeoArgs` flags are safe there.
-    */
   def geoSearchStore(destination: K, key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, storeDist: Boolean): F[Long]
-  /** @param args Only `count`/`sort` (i.e. COUNT/ASC/DESC) are meaningful here — GEOSEARCHSTORE
-    *             rejects the WITHDIST/WITHHASH/WITHCOORD flags that GeoArgs can also carry.
-    */
-  def geoSearchStore(destination: K, key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate, storeDist: Boolean, args: GeoArgs): F[Long]
+  def geoSearchStore(
+      destination: K,
+      key: K,
+      ref: GeoSearchReference[V],
+      predicate: GeoSearchPredicate,
+      storeDist: Boolean,
+      args: GeoStoreArgs
+  ): F[Long]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
@@ -54,8 +54,6 @@ trait HashSetter[F[_], K, V] {
   def hSet(key: K, field: K, value: V): F[Boolean]
   def hSet(key: K, fieldValues: Map[K, V]): F[Long]
   def hSetNx(key: K, field: K, value: V): F[Boolean]
-  @deprecated("In favor of hSet(key: K, fieldValues: Map[K, V])", since = "1.0.1")
-  def hmSet(key: K, fieldValues: Map[K, V]): F[Unit]
 }
 
 trait HashExpire[F[_], K] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/lists.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/lists.scala
@@ -17,6 +17,7 @@
 package dev.profunktor.redis4cats.algebra
 
 import cats.data.NonEmptyList
+import dev.profunktor.redis4cats.effects.LMoveSide
 
 import scala.concurrent.duration.Duration
 
@@ -30,6 +31,13 @@ trait ListBlocking[F[_], K, V] {
   def blPop(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, V)]]
   def brPop(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, V)]]
   def brPopLPush(timeout: Duration, source: K, destination: K): F[Option[V]]
+  def blMove(
+      timeout: Duration,
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide
+  ): F[Option[V]]
 }
 
 trait ListGetter[F[_], K, V] {
@@ -52,6 +60,7 @@ trait ListPushPop[F[_], K, V] {
   def lPushX(key: K, values: V*): F[Long]
   def rPop(key: K): F[Option[V]]
   def rPopLPush(source: K, destination: K): F[Option[V]]
+  def lMove(source: K, destination: K, sourceSide: LMoveSide, destinationSide: LMoveSide): F[Option[V]]
   def rPush(key: K, values: V*): F[Long]
   def rPushX(key: K, values: V*): F[Long]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sets.scala
@@ -32,7 +32,7 @@ trait SetGetter[F[_], K, V] {
   def sRandMember(key: K): F[Option[V]]
   def sRandMember(key: K, count: Long): F[List[V]]
   def sUnion(keys: K*): F[Set[V]]
-  def sUnionStore(destination: K, keys: K*): F[Unit]
+  def sUnionStore(destination: K, keys: K*): F[Long]
   def sScan(key: K): F[ValueScanCursor[V]]
   def sScan(key: K, cursor: ValueScanCursor[V]): F[ValueScanCursor[V]]
   def sScan(key: K, scanArgs: ScanArgs): F[ValueScanCursor[V]]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -40,13 +40,13 @@ trait Getter[F[_], K, V] {
 }
 
 trait Setter[F[_], K, V] {
-  def append(key: K, value: V): F[Unit]
+  def append(key: K, value: V): F[Long]
   def getSet(key: K, value: V): F[Option[V]]
   def set(key: K, value: V): F[Unit]
   def set(key: K, value: V, setArgs: SetArgs): F[Boolean]
   def setNx(key: K, value: V): F[Boolean]
   def setEx(key: K, value: V, expiresIn: FiniteDuration): F[Unit]
-  def setRange(key: K, value: V, offset: Long): F[Unit]
+  def setRange(key: K, value: V, offset: Long): F[Long]
 }
 
 trait MultiKey[F[_], K, V] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -38,12 +38,21 @@ object effects {
   final case class Longitude(value: Double) extends AnyVal
 
   final case class GeoLocation[V](lon: Longitude, lat: Latitude, value: V)
-  final case class GeoRadius(lon: Longitude, lat: Latitude, dist: Distance)
+
+  sealed trait GeoSearchReference[V]
+  object GeoSearchReference {
+    final case class FromCoordinates[V](lon: Longitude, lat: Latitude) extends GeoSearchReference[V]
+    final case class FromMember[V](value: V) extends GeoSearchReference[V]
+  }
+
+  sealed trait GeoSearchPredicate
+  object GeoSearchPredicate {
+    final case class ByRadius(dist: Distance, unit: GeoArgs.Unit) extends GeoSearchPredicate
+    final case class ByBox(width: Distance, height: Distance, unit: GeoArgs.Unit) extends GeoSearchPredicate
+  }
 
   final case class GeoCoordinate(x: Double, y: Double)
   final case class GeoRadiusResult[V](value: V, dist: Distance, hash: GeoHash, coordinate: GeoCoordinate)
-  final case class GeoRadiusKeyStorage[K](key: K, count: Long, sort: GeoArgs.Sort)
-  final case class GeoRadiusDistStorage[K](key: K, count: Long, sort: GeoArgs.Sort)
 
   final case class Score(value: Double) extends AnyVal
   final case class ScoreWithValue[V](score: Score, value: V)

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -442,6 +442,12 @@ object effects {
     def apply(ex: SetArg.Existence, ttl: SetArg.Ttl): SetArgs = SetArgs(Some(ex), Some(ttl))
   }
 
+  sealed trait LMoveSide
+  object LMoveSide {
+    case object Left extends LMoveSide
+    case object Right extends LMoveSide
+  }
+
   sealed trait ExpireExistenceArg
   object ExpireExistenceArg {
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -53,11 +53,21 @@ object effects {
 
   final case class GeoCoordinate(x: Double, y: Double)
 
-  /** `dist`/`hash`/`coordinate` are only meaningful when the `GeoArgs` passed to the `geoSearch` call that produced
-    * this result set the corresponding `withDistance()`/`withHash()`/ `withCoordinates()` flag — otherwise these fields
-    * reflect Lettuce's unset/default values.
+  /** `dist`/`hash`/`coordinate` are each present only when the `GeoArgs` passed to the `geoSearch` call that produced
+    * this result set the corresponding `withDistance()`/`withHash()`/ `withCoordinates()` flag — `None` otherwise,
+    * matching Lettuce's own `GeoWithin` contract ("if requested, otherwise null").
     */
-  final case class GeoRadiusResult[V](value: V, dist: Distance, hash: GeoHash, coordinate: GeoCoordinate)
+  final case class GeoSearchResult[V](
+      value: V,
+      dist: Option[Distance],
+      hash: Option[GeoHash],
+      coordinate: Option[GeoCoordinate]
+  )
+
+  /** The subset of `GeoArgs` that `GEOSEARCHSTORE` actually accepts (COUNT/ASC/DESC) — unlike `GEOSEARCH`, it rejects
+    * the WITHDIST/WITHHASH/WITHCOORD flags a raw `GeoArgs` could also carry.
+    */
+  final case class GeoStoreArgs(count: Option[Long] = None, sort: Option[GeoArgs.Sort] = None)
 
   final case class Score(value: Double) extends AnyVal
   final case class ScoreWithValue[V](score: Score, value: V)

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -52,6 +52,11 @@ object effects {
   }
 
   final case class GeoCoordinate(x: Double, y: Double)
+
+  /** `dist`/`hash`/`coordinate` are only meaningful when the `GeoArgs` passed to the `geoSearch` call that produced
+    * this result set the corresponding `withDistance()`/`withHash()`/ `withCoordinates()` flag — otherwise these fields
+    * reflect Lettuce's unset/default values.
+    */
   final case class GeoRadiusResult[V](value: V, dist: Distance, hash: GeoHash, coordinate: GeoCoordinate)
 
   final case class Score(value: Double) extends AnyVal

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1329,6 +1329,13 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
         GeoSearch.byBox(width.value, height.value, unit)
     }
 
+  private def toGeoArgs(args: GeoStoreArgs): GeoArgs = {
+    val jArgs = new GeoArgs()
+    args.count.foreach(jArgs.withCount)
+    args.sort.foreach(jArgs.sort)
+    jArgs
+  }
+
   override def geoSearch(key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate): F[Set[V]] =
     async
       .flatMap(_.geosearch(key, toGeoRef(ref), toGeoPredicate(predicate)).futureLift)
@@ -1339,10 +1346,10 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       ref: GeoSearchReference[V],
       predicate: GeoSearchPredicate,
       args: GeoArgs
-  ): F[List[GeoRadiusResult[V]]] =
+  ): F[List[GeoSearchResult[V]]] =
     async
       .flatMap(_.geosearch(key, toGeoRef(ref), toGeoPredicate(predicate), args).futureLift)
-      .map(_.asScala.toList.map(_.asGeoRadiusResult))
+      .map(_.asScala.toList.map(_.asGeoSearchResult))
 
   override def geoAdd(key: K, geoValues: GeoLocation[V]*): F[Long] = {
     val triplets = geoValues.flatMap(g => Seq[Any](g.lon.value, g.lat.value, g.value)).asInstanceOf[Seq[AnyRef]]
@@ -1356,7 +1363,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       predicate: GeoSearchPredicate,
       storeDist: Boolean
   ): F[Long] =
-    geoSearchStore(destination, key, ref, predicate, storeDist, new GeoArgs())
+    geoSearchStore(destination, key, ref, predicate, storeDist, GeoStoreArgs())
 
   override def geoSearchStore(
       destination: K,
@@ -1364,10 +1371,17 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       ref: GeoSearchReference[V],
       predicate: GeoSearchPredicate,
       storeDist: Boolean,
-      args: GeoArgs
+      args: GeoStoreArgs
   ): F[Long] =
     async.flatMap(
-      _.geosearchstore(destination, key, toGeoRef(ref), toGeoPredicate(predicate), args, storeDist).futureLift
+      _.geosearchstore(
+        destination,
+        key,
+        toGeoRef(ref),
+        toGeoPredicate(predicate),
+        toGeoArgs(args),
+        storeDist
+      ).futureLift
         .map(x => Long.box(x))
     )
 
@@ -2221,13 +2235,16 @@ private[redis4cats] trait RedisConversionOps {
 
   import dev.profunktor.redis4cats.JavaConversions._
 
-  private[redis4cats] implicit class GeoRadiusResultOps[V](v: GeoWithin[V]) {
-    def asGeoRadiusResult: GeoRadiusResult[V] =
-      GeoRadiusResult[V](
+  private[redis4cats] implicit class GeoWithinOps[V](v: GeoWithin[V]) {
+    // Lettuce's GeoWithin fields are null unless the corresponding GeoArgs flag was requested
+    // ("if requested, otherwise null" per its own scaladoc) — Option(...) is the correct, safe
+    // check here, since it wraps the (possibly-null) boxed reference before anything unboxes it.
+    def asGeoSearchResult: GeoSearchResult[V] =
+      GeoSearchResult[V](
         v.getMember,
-        Distance(v.getDistance),
-        GeoHash(v.getGeohash),
-        GeoCoordinate(v.getCoordinates.getX.doubleValue(), v.getCoordinates.getY.doubleValue())
+        Option(v.getDistance).map(Distance(_)),
+        Option(v.getGeohash).map(GeoHash(_)),
+        Option(v.getCoordinates).map(c => GeoCoordinate(c.getX.doubleValue(), c.getY.doubleValue()))
       )
   }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1161,9 +1161,29 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       .flatMap(_.brpop(timeout.toSecondsOrZero, keys.toList: _*).futureLift)
       .map(Option(_).map(kv => kv.getKey -> kv.getValue))
 
+  private def toLMoveArgs(sourceSide: LMoveSide, destinationSide: LMoveSide): LMoveArgs =
+    (sourceSide, destinationSide) match {
+      case (LMoveSide.Left, LMoveSide.Left)   => LMoveArgs.Builder.leftLeft()
+      case (LMoveSide.Left, LMoveSide.Right)  => LMoveArgs.Builder.leftRight()
+      case (LMoveSide.Right, LMoveSide.Left)  => LMoveArgs.Builder.rightLeft()
+      case (LMoveSide.Right, LMoveSide.Right) => LMoveArgs.Builder.rightRight()
+    }
+
   override def brPopLPush(timeout: Duration, source: K, destination: K): F[Option[V]] =
     async.flatMap(
       _.blmove(source, destination, LMoveArgs.Builder.rightLeft(), timeout.toSecondsOrZero).futureLift.map(Option.apply)
+    )
+
+  override def blMove(
+      timeout: Duration,
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide
+  ): F[Option[V]] =
+    async.flatMap(
+      _.blmove(source, destination, toLMoveArgs(sourceSide, destinationSide), timeout.toSecondsOrZero).futureLift
+        .map(Option.apply)
     )
 
   override def lPop(key: K): F[Option[V]] =
@@ -1180,6 +1200,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def rPopLPush(source: K, destination: K): F[Option[V]] =
     async.flatMap(_.lmove(source, destination, LMoveArgs.Builder.rightLeft()).futureLift.map(Option.apply))
+
+  override def lMove(source: K, destination: K, sourceSide: LMoveSide, destinationSide: LMoveSide): F[Option[V]] =
+    async.flatMap(_.lmove(source, destination, toLMoveArgs(sourceSide, destinationSide)).futureLift.map(Option.apply))
 
   override def rPush(key: K, values: V*): F[Long] =
     async.flatMap(_.rpush(key, values: _*).futureLift.map(x => Long.box(x)))

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1067,9 +1067,6 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def hSetNx(key: K, field: K, value: V): F[Boolean] =
     async.flatMap(_.hsetnx(key, field, value).futureLift.map(x => Boolean.box(x)))
 
-  override def hmSet(key: K, fieldValues: Map[K, V]): F[Unit] =
-    async.flatMap(_.hset(key, fieldValues.asJava).futureLift.void)
-
   override def hIncrBy(key: K, field: K, amount: Long): F[Long] =
     async.flatMap(_.hincrby(key, field, amount).futureLift.map(x => Long.box(x)))
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -677,8 +677,8 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   // format: off
   /******************************* Strings API **********************************/
   // format: on
-  override def append(key: K, value: V): F[Unit] =
-    async.flatMap(_.append(key, value).futureLift.void)
+  override def append(key: K, value: V): F[Long] =
+    async.flatMap(_.append(key, value).futureLift.map(x => Long.box(x)))
 
   override def getSet(key: K, value: V): F[Option[V]] =
     async.flatMap(_.setGet(key, value).futureLift.map(Option.apply))
@@ -714,8 +714,8 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
         async.flatMap(_.set(key, value, new JSetArgs().ex(expiresIn.toSeconds)).futureLift.void)
     }
 
-  override def setRange(key: K, value: V, offset: Long): F[Unit] =
-    async.flatMap(_.setrange(key, offset, value).futureLift.void)
+  override def setRange(key: K, value: V, offset: Long): F[Long] =
+    async.flatMap(_.setrange(key, offset, value).futureLift.map(x => Long.box(x)))
 
   override def decr(key: K): F[Long] =
     async.flatMap(_.decr(key).futureLift.map(x => Long.box(x)))
@@ -1123,8 +1123,8 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def sUnion(keys: K*): F[Set[V]] =
     async.flatMap(_.sunion(keys: _*).futureLift.map(_.asScala.toSet))
 
-  override def sUnionStore(destination: K, keys: K*): F[Unit] =
-    async.flatMap(_.sunionstore(destination, keys: _*).futureLift.void)
+  override def sUnionStore(destination: K, keys: K*): F[Long] =
+    async.flatMap(_.sunionstore(destination, keys: _*).futureLift.map(x => Long.box(x)))
 
   override def sScan(key: K): F[ValueScanCursor[V]] =
     async.flatMap(_.sscan(key).futureLift.map(ValueScanCursor[V]))
@@ -1269,17 +1269,17 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def bitPos(key: K, state: Boolean, start: Long, end: Long): F[Long] =
     async.flatMap(_.bitpos(key, state, start, end).futureLift.map(x => Long.box(x)))
 
-  override def bitOpAnd(destination: K, source: K, sources: K*): F[Unit] =
-    async.flatMap(_.bitopAnd(destination, (source +: sources): _*).futureLift.void)
+  override def bitOpAnd(destination: K, source: K, sources: K*): F[Long] =
+    async.flatMap(_.bitopAnd(destination, (source +: sources): _*).futureLift.map(x => Long.box(x)))
 
-  override def bitOpNot(destination: K, source: K): F[Unit] =
-    async.flatMap(_.bitopNot(destination, source).futureLift.void)
+  override def bitOpNot(destination: K, source: K): F[Long] =
+    async.flatMap(_.bitopNot(destination, source).futureLift.map(x => Long.box(x)))
 
-  override def bitOpOr(destination: K, source: K, sources: K*): F[Unit] =
-    async.flatMap(_.bitopOr(destination, (source +: sources): _*).futureLift.void)
+  override def bitOpOr(destination: K, source: K, sources: K*): F[Long] =
+    async.flatMap(_.bitopOr(destination, (source +: sources): _*).futureLift.map(x => Long.box(x)))
 
-  override def bitOpXor(destination: K, source: K, sources: K*): F[Unit] =
-    async.flatMap(_.bitopXor(destination, (source +: sources): _*).futureLift.void)
+  override def bitOpXor(destination: K, source: K, sources: K*): F[Long] =
+    async.flatMap(_.bitopXor(destination, (source +: sources): _*).futureLift.map(x => Long.box(x)))
 
   override def getBit(key: K, offset: Long): F[Option[Long]] =
     async.flatMap(_.getbit(key, offset).futureLift.map(x => Option(Long.unbox(x))))

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -46,7 +46,6 @@ import io.lettuce.core.{
   FlushMode => JFlushMode,
   FunctionRestoreMode => JFunctionRestoreMode,
   GeoArgs,
-  GeoRadiusStoreArgs,
   GeoSearch,
   GeoWithin,
   GetExArgs => JGetExArgs,
@@ -1304,94 +1303,73 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       .flatMap(_.geopos(key, (value +: values): _*).futureLift)
       .map(_.asScala.toList.map(c => GeoCoordinate(c.getX.doubleValue(), c.getY.doubleValue())))
 
-  override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit): F[Set[V]] =
+  private def toGeoRef(ref: GeoSearchReference[V]): GeoSearch.GeoRef[K] =
+    ref match {
+      case GeoSearchReference.FromCoordinates(lon, lat) =>
+        GeoSearch.fromCoordinates(lon.value, lat.value)
+      case GeoSearchReference.FromMember(value) =>
+        // Lettuce's GeoSearch.fromMember is generically typed over K (Lettuce's own source
+        // marks this "TODO: Should be V") and internally encodes the member using the key
+        // codec instead of the value codec via an unchecked cast. For a RedisCodec[K, V]
+        // where K and V are encoded differently, this can produce a mismatched encoding on
+        // the wire. This is a real, currently-shipped Lettuce bug (see
+        // https://github.com/redis/lettuce/issues/826 for the identical class of bug,
+        // previously reported and fixed for ZINCRBY), not something redis4cats works around:
+        // using the modern GEOSEARCH API uniformly here, since the legacy GEORADIUSBYMEMBER
+        // command never supported box-shaped search and so has no safe fallback for every
+        // case anyway.
+        GeoSearch.fromMember[K](value.asInstanceOf[K])
+    }
+
+  private def toGeoPredicate(predicate: GeoSearchPredicate): GeoSearch.GeoPredicate =
+    predicate match {
+      case GeoSearchPredicate.ByRadius(dist, unit) =>
+        GeoSearch.byRadius(dist.value, unit)
+      case GeoSearchPredicate.ByBox(width, height, unit) =>
+        GeoSearch.byBox(width.value, height.value, unit)
+    }
+
+  override def geoSearch(key: K, ref: GeoSearchReference[V], predicate: GeoSearchPredicate): F[Set[V]] =
     async
-      .flatMap(
-        _.geosearch(
-          key,
-          GeoSearch.fromCoordinates(geoRadius.lon.value, geoRadius.lat.value),
-          GeoSearch.byRadius(geoRadius.dist.value, unit)
-        ).futureLift
-      )
+      .flatMap(_.geosearch(key, toGeoRef(ref), toGeoPredicate(predicate)).futureLift)
       .map(_.asScala.toSet)
 
-  override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, args: GeoArgs): F[List[GeoRadiusResult[V]]] =
-    async
-      .flatMap(
-        _.geosearch(
-          key,
-          GeoSearch.fromCoordinates(geoRadius.lon.value, geoRadius.lat.value),
-          GeoSearch.byRadius(geoRadius.dist.value, unit),
-          args
-        ).futureLift
-      )
-      .map(_.asScala.toList.map(_.asGeoRadiusResult))
-
-  // georadiusbymember stays on the deprecated Lettuce API rather than geosearch/GeoSearch.fromMember:
-  // fromMember is typed `[K](member: K)` in Lettuce (a known upstream bug, marked "TODO: Should be
-  // V" in Lettuce's own source) and its build() encodes the member with the *key* codec via
-  // addKey(), not the value codec. For a RedisCodec[K, V] where K and V differ, that would silently
-  // miscode the member on the wire. georadiusbymember correctly takes the member as V.
-  override def geoRadiusByMember(key: K, value: V, dist: Distance, unit: GeoArgs.Unit): F[Set[V]] =
-    async.flatMap(_.georadiusbymember(key, value, dist.value, unit).futureLift.map(_.asScala.toSet))
-
-  override def geoRadiusByMember(
+  override def geoSearch(
       key: K,
-      value: V,
-      dist: Distance,
-      unit: GeoArgs.Unit,
+      ref: GeoSearchReference[V],
+      predicate: GeoSearchPredicate,
       args: GeoArgs
   ): F[List[GeoRadiusResult[V]]] =
     async
-      .flatMap(_.georadiusbymember(key, value, dist.value, unit, args).futureLift)
+      .flatMap(_.geosearch(key, toGeoRef(ref), toGeoPredicate(predicate), args).futureLift)
       .map(_.asScala.toList.map(_.asGeoRadiusResult))
 
-  override def geoAdd(key: K, geoValues: GeoLocation[V]*): F[Unit] = {
+  override def geoAdd(key: K, geoValues: GeoLocation[V]*): F[Long] = {
     val triplets = geoValues.flatMap(g => Seq[Any](g.lon.value, g.lat.value, g.value)).asInstanceOf[Seq[AnyRef]]
-    async.flatMap(_.geoadd(key, triplets: _*).futureLift.void)
+    async.flatMap(_.geoadd(key, triplets: _*).futureLift.map(x => Long.box(x)))
   }
 
-  override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, storage: GeoRadiusKeyStorage[K]): F[Unit] =
-    conn.async.flatMap {
-      _.geosearchstore(
-        storage.key,
-        key,
-        GeoSearch.fromCoordinates(geoRadius.lon.value, geoRadius.lat.value),
-        GeoSearch.byRadius(geoRadius.dist.value, unit),
-        storage.asGeoArgs,
-        false
-      ).futureLift.void
-    }
-
-  override def geoRadius(key: K, geoRadius: GeoRadius, unit: GeoArgs.Unit, storage: GeoRadiusDistStorage[K]): F[Unit] =
-    conn.async.flatMap {
-      _.geosearchstore(
-        storage.key,
-        key,
-        GeoSearch.fromCoordinates(geoRadius.lon.value, geoRadius.lat.value),
-        GeoSearch.byRadius(geoRadius.dist.value, unit),
-        storage.asGeoArgs,
-        true
-      ).futureLift.void
-    }
-
-  override def geoRadiusByMember(
+  override def geoSearchStore(
+      destination: K,
       key: K,
-      value: V,
-      dist: Distance,
-      unit: GeoArgs.Unit,
-      storage: GeoRadiusKeyStorage[K]
-  ): F[Unit] =
-    async.flatMap(_.georadiusbymember(key, value, dist.value, unit, storage.asGeoRadiusStoreArgs).futureLift.void)
+      ref: GeoSearchReference[V],
+      predicate: GeoSearchPredicate,
+      storeDist: Boolean
+  ): F[Long] =
+    geoSearchStore(destination, key, ref, predicate, storeDist, new GeoArgs())
 
-  override def geoRadiusByMember(
+  override def geoSearchStore(
+      destination: K,
       key: K,
-      value: V,
-      dist: Distance,
-      unit: GeoArgs.Unit,
-      storage: GeoRadiusDistStorage[K]
-  ): F[Unit] =
-    async.flatMap(_.georadiusbymember(key, value, dist.value, unit, storage.asGeoRadiusStoreArgs).futureLift.void)
+      ref: GeoSearchReference[V],
+      predicate: GeoSearchPredicate,
+      storeDist: Boolean,
+      args: GeoArgs
+  ): F[Long] =
+    async.flatMap(
+      _.geosearchstore(destination, key, toGeoRef(ref), toGeoPredicate(predicate), args, storeDist).futureLift
+        .map(x => Long.box(x))
+    )
 
   // format: off
   /******************************* Sorted Sets API **********************************/
@@ -2251,28 +2229,6 @@ private[redis4cats] trait RedisConversionOps {
         GeoHash(v.getGeohash),
         GeoCoordinate(v.getCoordinates.getX.doubleValue(), v.getCoordinates.getY.doubleValue())
       )
-  }
-
-  private[redis4cats] implicit class GeoRadiusKeyStorageOps[K](v: GeoRadiusKeyStorage[K]) {
-    def asGeoArgs: GeoArgs = new GeoArgs().withCount(v.count).sort(v.sort)
-
-    def asGeoRadiusStoreArgs: GeoRadiusStoreArgs[K] = {
-      val store: GeoRadiusStoreArgs[_] = GeoRadiusStoreArgs.Builder
-        .store[K](v.key)
-        .withCount(v.count)
-      store.asInstanceOf[GeoRadiusStoreArgs[K]]
-    }
-  }
-
-  private[redis4cats] implicit class GeoRadiusDistStorageOps[K](v: GeoRadiusDistStorage[K]) {
-    def asGeoArgs: GeoArgs = new GeoArgs().withCount(v.count).sort(v.sort)
-
-    def asGeoRadiusStoreArgs: GeoRadiusStoreArgs[K] = {
-      val store: GeoRadiusStoreArgs[_] = GeoRadiusStoreArgs.Builder
-        .withStoreDist[K](v.key)
-        .withCount(v.count)
-      store.asInstanceOf[GeoRadiusStoreArgs[K]]
-    }
   }
 
   private[redis4cats] implicit class ZRangeOps[T: Numeric](range: ZRange[T]) {

--- a/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
+++ b/modules/examples/src/main/scala/dev/profunktor/redis4cats/RedisGeoDemo.scala
@@ -47,7 +47,11 @@ object RedisGeoDemo extends LoggerIOApp {
         _ <- IO.println(s"Distance from ${_BuenosAires.value} to Tokyo: $x km")
         y <- redis.geoPos(testKey, _RioDeJaneiro.value)
         _ <- IO.println(s"Geo Pos of ${_RioDeJaneiro.value}: ${y.headOption}")
-        z <- redis.geoRadius(testKey, GeoRadius(_Montevideo.lon, _Montevideo.lat, Distance(10000.0)), GeoArgs.Unit.km)
+        z <- redis.geoSearch(
+               testKey,
+               GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
+               GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km)
+             )
         _ <- IO.println(s"Geo Radius in 1000 km: $z")
       } yield ()
     }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -404,6 +404,12 @@ trait TestScenarios { self: FunSuite =>
           (sScanKey, ScanArgs("*r*", count = 3L))
         ) { case (k, a) => redis.sScan(k, a) } { case ((k, a), c) => redis.sScan(k, c, a) }
       _ <- IO(assertEquals(sScanSeqResR, sScanSeqR))
+      _ <- redis.sAdd("sunion-a", "1", "2")
+      _ <- redis.sAdd("sunion-b", "2", "3")
+      unionCount <- redis.sUnionStore("sunion-dest", "sunion-a", "sunion-b")
+      _ <- IO(assertEquals(unionCount, 3L))
+      unionMembers <- redis.sMembers("sunion-dest")
+      _ <- IO(assertEquals(unionMembers, Set("1", "2", "3")))
     } yield ()
   }
 
@@ -711,15 +717,24 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assertEquals(bitLen2, 2.toLong))
       _ <- redis.setBit(key, 0, 1)
       _ <- redis.setBit(secondKey, 0, 1)
-      _ <- redis.bitOpAnd(thirdKey, key, secondKey)
+      andLen <- redis.bitOpAnd(thirdKey, key, secondKey)
+      _ <- IO(assertEquals(andLen, 1L)) // both source keys are 1 byte long
       r <- redis.getBit(thirdKey, 0)
       _ <- IO(assertEquals(r, Some(1.toLong)))
-      _ <- redis.bitOpNot(thirdKey, key)
+      notLen <- redis.bitOpNot(thirdKey, key)
+      _ <- IO(assertEquals(notLen, 1L)) // result length == source's own length
       r2 <- redis.getBit(thirdKey, 0)
       _ <- IO(assertEquals(r2, Some(0.toLong)))
-      _ <- redis.bitOpOr(thirdKey, key, secondKey)
+      orLen <- redis.bitOpOr(thirdKey, key, secondKey)
+      _ <- IO(assertEquals(orLen, 1L))
       r3 <- redis.getBit(thirdKey, 0)
       _ <- IO(assertEquals(r3, Some(1.toLong)))
+      xorLen <- redis.bitOpXor(thirdKey, key, secondKey)
+      _ <- IO(assertEquals(xorLen, 1L))
+      _ <- redis.setBit("bitop-long", 20, 1) // 3 bytes long
+      _ <- redis.setBit("bitop-short", 0, 1) // 1 byte long
+      orDifferentLengths <- redis.bitOpOr("bitop-result", "bitop-long", "bitop-short")
+      _ <- IO(assertEquals(orDifferentLengths, 3L)) // result length == longest source
       _ <- for {
              s1 <- redis.setBit(key, 2, 1)
              s2 <- redis.setBit(key, 3, 1)
@@ -812,6 +827,16 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assert(getDelExisting.contains("valueToGetDel")))
       getDelAfter <- redis.get("keyToGetDel")
       _ <- IO(assert(getDelAfter.isEmpty))
+      appendLen1 <- redis.append("append-key", "Hello")
+      _ <- IO(assertEquals(appendLen1, 5L))
+      appendLen2 <- redis.append("append-key", " World")
+      _ <- IO(assertEquals(appendLen2, 11L)) // cumulative length
+      appendVal <- redis.get("append-key")
+      _ <- IO(assertEquals(appendVal, Some("Hello World")))
+      setRangeLen <- redis.setRange("append-key", "Redis", 6)
+      _ <- IO(assertEquals(setRangeLen, 11L))
+      setRangeVal <- redis.get("append-key")
+      _ <- IO(assertEquals(setRangeVal, Some("Hello Redis")))
     } yield ()
   }
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -67,7 +67,7 @@ trait TestScenarios { self: FunSuite =>
              )
            )
 
-      // geoSearch: FromCoordinates x ByRadius, with GeoArgs (List[GeoRadiusResult[V]] result)
+      // geoSearch: FromCoordinates x ByRadius, with GeoArgs (List[GeoSearchResult[V]] result)
       byCoordRadiusArgs <- redis.geoSearch(
                              testKey,
                              GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
@@ -165,7 +165,7 @@ trait TestScenarios { self: FunSuite =>
                        GeoSearchReference.FromMember(_Montevideo.value),
                        GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
                        storeDist = false,
-                       new GeoArgs().withCount(1)
+                       GeoStoreArgs(count = Some(1))
                      )
       _ <- IO(assertEquals(storeCount3, 1L))
 
@@ -223,7 +223,8 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assertEquals(d, 1L))
       z <- redis.hGet(testKey, testField)
       _ <- IO(assert(z.isEmpty))
-      _ <- redis.hSet(testKey, Map(testField -> "some value", testField2 -> "another value"))
+      hSetCount <- redis.hSet(testKey, Map(testField -> "some value", testField2 -> "another value"))
+      _ <- IO(assertEquals(hSetCount, 2L)) // both fields are new, per hDel above
       v <- redis.hGet(testKey, testField)
       _ <- IO(assert(v.contains("some value")))
       v <- redis.hGet(testKey, testField2)

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -41,7 +41,7 @@ trait TestScenarios { self: FunSuite =>
     val _Montevideo   = GeoLocation(Longitude(-56.164532), Latitude(-34.901112), "Montevideo")
     val _Tokyo        = GeoLocation(Longitude(139.6917), Latitude(35.6895), "Tokyo")
 
-    val testKey = "location"
+    val testKey = "{geosearch}:location"
     for {
       addCount1 <- redis.geoAdd(testKey, _BuenosAires)
       _ <- IO(assertEquals(addCount1, 1L))
@@ -72,7 +72,7 @@ trait TestScenarios { self: FunSuite =>
                              testKey,
                              GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
                              GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
-                             new GeoArgs()
+                             GeoArgs.Builder.full()
                            )
       _ <- IO(assert(byCoordRadiusArgs.map(_.value).toSet == byCoordRadius))
 
@@ -89,7 +89,7 @@ trait TestScenarios { self: FunSuite =>
                               testKey,
                               GeoSearchReference.FromMember(_Montevideo.value),
                               GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
-                              new GeoArgs()
+                              GeoArgs.Builder.full()
                             )
       _ <- IO(assertEquals(byMemberRadiusArgs.map(_.value).toSet, byCoordRadius))
 
@@ -138,19 +138,19 @@ trait TestScenarios { self: FunSuite =>
 
       // geoSearchStore: FromCoordinates, storeDist = false
       storeCount1 <- redis.geoSearchStore(
-                       "location-store-1",
+                       "{geosearch}:location-store-1",
                        testKey,
                        GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
                        GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
                        storeDist = false
                      )
       _ <- IO(assertEquals(storeCount1, 3L))
-      storedMembers1 <- redis.zRange("location-store-1", 0, -1)
+      storedMembers1 <- redis.zRange("{geosearch}:location-store-1", 0, -1)
       _ <- IO(assertEquals(storedMembers1.toSet, byCoordRadius))
 
       // geoSearchStore: FromCoordinates, storeDist = true
       storeCount2 <- redis.geoSearchStore(
-                       "location-store-2",
+                       "{geosearch}:location-store-2",
                        testKey,
                        GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
                        GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
@@ -160,7 +160,7 @@ trait TestScenarios { self: FunSuite =>
 
       // geoSearchStore: FromMember, storeDist = false, with GeoArgs (count = 1)
       storeCount3 <- redis.geoSearchStore(
-                       "location-store-3",
+                       "{geosearch}:location-store-3",
                        testKey,
                        GeoSearchReference.FromMember(_Montevideo.value),
                        GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
@@ -171,7 +171,7 @@ trait TestScenarios { self: FunSuite =>
 
       // geoSearchStore: FromMember, storeDist = true
       storeCount4 <- redis.geoSearchStore(
-                       "location-store-4",
+                       "{geosearch}:location-store-4",
                        testKey,
                        GeoSearchReference.FromMember(_Montevideo.value),
                        GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
@@ -181,7 +181,7 @@ trait TestScenarios { self: FunSuite =>
 
       // geoSearchStore: empty result stores nothing
       storeCountEmpty <- redis.geoSearchStore(
-                           "location-store-empty",
+                           "{geosearch}:location-store-empty",
                            testKey,
                            GeoSearchReference.FromCoordinates(Longitude(0.0), Latitude(0.0)),
                            GeoSearchPredicate.ByRadius(Distance(1.0), GeoArgs.Unit.km),
@@ -327,36 +327,43 @@ trait TestScenarios { self: FunSuite =>
       h <- redis.lRange(testKey, 0, 10)
       _ <- IO(assertEquals(h, List("four")))
       // lMove: all 4 direction combinations
-      _ <- redis.rPush("lmove-src", "a", "b", "c")
-      lmRL <- redis.lMove("lmove-src", "lmove-dst", LMoveSide.Right, LMoveSide.Left)
+      _ <- redis.rPush("{listmove}:lmove-src", "a", "b", "c")
+      lmRL <- redis.lMove("{listmove}:lmove-src", "{listmove}:lmove-dst", LMoveSide.Right, LMoveSide.Left)
       _ <- IO(assertEquals(lmRL, Some("c")))
-      lmDst1 <- redis.lRange("lmove-dst", 0, -1)
+      lmDst1 <- redis.lRange("{listmove}:lmove-dst", 0, -1)
       _ <- IO(assertEquals(lmDst1, List("c")))
-      lmLL <- redis.lMove("lmove-src", "lmove-dst", LMoveSide.Left, LMoveSide.Left)
+      lmLL <- redis.lMove("{listmove}:lmove-src", "{listmove}:lmove-dst", LMoveSide.Left, LMoveSide.Left)
       _ <- IO(assertEquals(lmLL, Some("a")))
-      lmDst2 <- redis.lRange("lmove-dst", 0, -1)
+      lmDst2 <- redis.lRange("{listmove}:lmove-dst", 0, -1)
       _ <- IO(assertEquals(lmDst2, List("a", "c")))
-      lmLR <- redis.lMove("lmove-src", "lmove-dst", LMoveSide.Left, LMoveSide.Right)
+      lmLR <- redis.lMove("{listmove}:lmove-src", "{listmove}:lmove-dst", LMoveSide.Left, LMoveSide.Right)
       _ <- IO(assertEquals(lmLR, Some("b")))
-      lmDst3 <- redis.lRange("lmove-dst", 0, -1)
+      lmDst3 <- redis.lRange("{listmove}:lmove-dst", 0, -1)
       _ <- IO(assertEquals(lmDst3, List("a", "c", "b")))
-      lmSrcEmpty <- redis.lRange("lmove-src", 0, -1)
+      lmSrcEmpty <- redis.lRange("{listmove}:lmove-src", 0, -1)
       _ <- IO(assert(lmSrcEmpty.isEmpty))
       // rightRight + self-rotation (source == destination)
-      _ <- redis.rPush("lmove-rot", "x", "y", "z")
-      lmRR <- redis.lMove("lmove-rot", "lmove-rot", LMoveSide.Right, LMoveSide.Right)
+      _ <- redis.rPush("{listmove}:lmove-rot", "x", "y", "z")
+      lmRR <- redis.lMove("{listmove}:lmove-rot", "{listmove}:lmove-rot", LMoveSide.Right, LMoveSide.Right)
       _ <- IO(assertEquals(lmRR, Some("z")))
-      lmRotResult <- redis.lRange("lmove-rot", 0, -1)
+      lmRotResult <- redis.lRange("{listmove}:lmove-rot", 0, -1)
       _ <- IO(assertEquals(lmRotResult, List("x", "y", "z")))
       // lMove on an empty source returns None
-      lmEmpty <- redis.lMove("lmove-does-not-exist", "lmove-dst", LMoveSide.Right, LMoveSide.Left)
+      lmEmpty <- redis.lMove("{listmove}:lmove-does-not-exist", "{listmove}:lmove-dst", LMoveSide.Right, LMoveSide.Left)
       _ <- IO(assertEquals(lmEmpty, None))
       // blMove: element available immediately
-      _ <- redis.rPush("blmove-src", "one")
-      blmImmediate <- redis.blMove(1.second, "blmove-src", "blmove-dst", LMoveSide.Right, LMoveSide.Left)
+      _ <- redis.rPush("{listmove}:blmove-src", "one")
+      blmImmediate <-
+        redis.blMove(1.second, "{listmove}:blmove-src", "{listmove}:blmove-dst", LMoveSide.Right, LMoveSide.Left)
       _ <- IO(assertEquals(blmImmediate, Some("one")))
       // blMove: timeout expiry with no element available
-      blmTimeout <- redis.blMove(1.second, "blmove-does-not-exist", "blmove-dst", LMoveSide.Right, LMoveSide.Left)
+      blmTimeout <- redis.blMove(
+                      1.second,
+                      "{listmove}:blmove-does-not-exist",
+                      "{listmove}:blmove-dst",
+                      LMoveSide.Right,
+                      LMoveSide.Left
+                    )
       _ <- IO(assertEquals(blmTimeout, None))
     } yield ()
   }
@@ -404,11 +411,11 @@ trait TestScenarios { self: FunSuite =>
           (sScanKey, ScanArgs("*r*", count = 3L))
         ) { case (k, a) => redis.sScan(k, a) } { case ((k, a), c) => redis.sScan(k, c, a) }
       _ <- IO(assertEquals(sScanSeqResR, sScanSeqR))
-      _ <- redis.sAdd("sunion-a", "1", "2")
-      _ <- redis.sAdd("sunion-b", "2", "3")
-      unionCount <- redis.sUnionStore("sunion-dest", "sunion-a", "sunion-b")
+      _ <- redis.sAdd("{sunion}:sunion-a", "1", "2")
+      _ <- redis.sAdd("{sunion}:sunion-b", "2", "3")
+      unionCount <- redis.sUnionStore("{sunion}:sunion-dest", "{sunion}:sunion-a", "{sunion}:sunion-b")
       _ <- IO(assertEquals(unionCount, 3L))
-      unionMembers <- redis.sMembers("sunion-dest")
+      unionMembers <- redis.sMembers("{sunion}:sunion-dest")
       _ <- IO(assertEquals(unionMembers, Set("1", "2", "3")))
     } yield ()
   }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -191,6 +191,38 @@ trait TestScenarios { self: FunSuite =>
       _ <- redis.lTrim(testKey, 1, 2)
       h <- redis.lRange(testKey, 0, 10)
       _ <- IO(assertEquals(h, List("four")))
+      // lMove: all 4 direction combinations
+      _ <- redis.rPush("lmove-src", "a", "b", "c")
+      lmRL <- redis.lMove("lmove-src", "lmove-dst", LMoveSide.Right, LMoveSide.Left)
+      _ <- IO(assertEquals(lmRL, Some("c")))
+      lmDst1 <- redis.lRange("lmove-dst", 0, -1)
+      _ <- IO(assertEquals(lmDst1, List("c")))
+      lmLL <- redis.lMove("lmove-src", "lmove-dst", LMoveSide.Left, LMoveSide.Left)
+      _ <- IO(assertEquals(lmLL, Some("a")))
+      lmDst2 <- redis.lRange("lmove-dst", 0, -1)
+      _ <- IO(assertEquals(lmDst2, List("a", "c")))
+      lmLR <- redis.lMove("lmove-src", "lmove-dst", LMoveSide.Left, LMoveSide.Right)
+      _ <- IO(assertEquals(lmLR, Some("b")))
+      lmDst3 <- redis.lRange("lmove-dst", 0, -1)
+      _ <- IO(assertEquals(lmDst3, List("a", "c", "b")))
+      lmSrcEmpty <- redis.lRange("lmove-src", 0, -1)
+      _ <- IO(assert(lmSrcEmpty.isEmpty))
+      // rightRight + self-rotation (source == destination)
+      _ <- redis.rPush("lmove-rot", "x", "y", "z")
+      lmRR <- redis.lMove("lmove-rot", "lmove-rot", LMoveSide.Right, LMoveSide.Right)
+      _ <- IO(assertEquals(lmRR, Some("z")))
+      lmRotResult <- redis.lRange("lmove-rot", 0, -1)
+      _ <- IO(assertEquals(lmRotResult, List("x", "y", "z")))
+      // lMove on an empty source returns None
+      lmEmpty <- redis.lMove("lmove-does-not-exist", "lmove-dst", LMoveSide.Right, LMoveSide.Left)
+      _ <- IO(assertEquals(lmEmpty, None))
+      // blMove: element available immediately
+      _ <- redis.rPush("blmove-src", "one")
+      blmImmediate <- redis.blMove(1.second, "blmove-src", "blmove-dst", LMoveSide.Right, LMoveSide.Left)
+      _ <- IO(assertEquals(blmImmediate, Some("one")))
+      // blMove: timeout expiry with no element available
+      blmTimeout <- redis.blMove(1.second, "blmove-does-not-exist", "blmove-dst", LMoveSide.Right, LMoveSide.Left)
+      _ <- IO(assertEquals(blmTimeout, None))
     } yield ()
   }
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -43,16 +43,151 @@ trait TestScenarios { self: FunSuite =>
 
     val testKey = "location"
     for {
-      _ <- redis.geoAdd(testKey, _BuenosAires)
+      addCount1 <- redis.geoAdd(testKey, _BuenosAires)
+      _ <- IO(assertEquals(addCount1, 1L))
       _ <- redis.geoAdd(testKey, _RioDeJaneiro)
       _ <- redis.geoAdd(testKey, _Montevideo)
       _ <- redis.geoAdd(testKey, _Tokyo)
+      addCountExisting <- redis.geoAdd(testKey, _Tokyo)
+      _ <- IO(assertEquals(addCountExisting, 0L)) // re-adding an existing member updates it, adds nothing new
       x <- redis.geoDist(testKey, _BuenosAires.value, _Tokyo.value, GeoArgs.Unit.km)
       _ <- IO(assertEquals(x, 18374.9052))
       y <- redis.geoPos(testKey, _RioDeJaneiro.value)
       _ <- IO(assert(y.contains(GeoCoordinate(-43.17289799451828, -22.906801071586663))))
-      z <- redis.geoRadius(testKey, GeoRadius(_Montevideo.lon, _Montevideo.lat, Distance(10000.0)), GeoArgs.Unit.km)
-      _ <- IO(assert(z.toList.containsSlice(List(_BuenosAires.value, _Montevideo.value, _RioDeJaneiro.value))))
+
+      // geoSearch: FromCoordinates x ByRadius (plain Set[V] result)
+      byCoordRadius <- redis.geoSearch(
+                         testKey,
+                         GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
+                         GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km)
+                       )
+      _ <- IO(
+             assert(
+               byCoordRadius.toList.containsSlice(List(_BuenosAires.value, _Montevideo.value, _RioDeJaneiro.value))
+             )
+           )
+
+      // geoSearch: FromCoordinates x ByRadius, with GeoArgs (List[GeoRadiusResult[V]] result)
+      byCoordRadiusArgs <- redis.geoSearch(
+                             testKey,
+                             GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
+                             GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
+                             new GeoArgs()
+                           )
+      _ <- IO(assert(byCoordRadiusArgs.map(_.value).toSet == byCoordRadius))
+
+      // geoSearch: FromMember x ByRadius
+      byMemberRadius <- redis.geoSearch(
+                          testKey,
+                          GeoSearchReference.FromMember(_Montevideo.value),
+                          GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km)
+                        )
+      _ <- IO(assertEquals(byMemberRadius, byCoordRadius))
+
+      // geoSearch: FromMember x ByRadius, with GeoArgs
+      byMemberRadiusArgs <- redis.geoSearch(
+                              testKey,
+                              GeoSearchReference.FromMember(_Montevideo.value),
+                              GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
+                              new GeoArgs()
+                            )
+      _ <- IO(assertEquals(byMemberRadiusArgs.map(_.value).toSet, byCoordRadius))
+
+      // geoSearch: FromCoordinates x ByBox (new capability, GEORADIUS never supported box search)
+      byCoordBox <- redis.geoSearch(
+                      testKey,
+                      GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
+                      GeoSearchPredicate.ByBox(Distance(10000.0), Distance(10000.0), GeoArgs.Unit.km)
+                    )
+      _ <- IO(assert(byCoordBox.contains(_Montevideo.value)))
+
+      // geoSearch: FromMember x ByBox (the combination with no legacy fallback)
+      byMemberBox <- redis.geoSearch(
+                       testKey,
+                       GeoSearchReference.FromMember(_Montevideo.value),
+                       GeoSearchPredicate.ByBox(Distance(10000.0), Distance(10000.0), GeoArgs.Unit.km)
+                     )
+      _ <- IO(assert(byMemberBox.contains(_Montevideo.value)))
+
+      // asymmetric box (width != height)
+      asymmetricBox <- redis.geoSearch(
+                         testKey,
+                         GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
+                         GeoSearchPredicate.ByBox(Distance(20000.0), Distance(1.0), GeoArgs.Unit.km)
+                       )
+      _ <- IO(assert(asymmetricBox.contains(_Montevideo.value)))
+
+      // empty result set: a tiny radius far from everything
+      emptyResult <- redis.geoSearch(
+                       testKey,
+                       GeoSearchReference.FromCoordinates(Longitude(0.0), Latitude(0.0)),
+                       GeoSearchPredicate.ByRadius(Distance(1.0), GeoArgs.Unit.km)
+                     )
+      _ <- IO(assert(emptyResult.isEmpty))
+
+      // FromMember referencing a non-existent member fails
+      nonExistentMemberAttempt <-
+        redis
+          .geoSearch(
+            testKey,
+            GeoSearchReference.FromMember("does-not-exist"),
+            GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km)
+          )
+          .attempt
+      _ <- IO(assert(nonExistentMemberAttempt.isLeft))
+
+      // geoSearchStore: FromCoordinates, storeDist = false
+      storeCount1 <- redis.geoSearchStore(
+                       "location-store-1",
+                       testKey,
+                       GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
+                       GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
+                       storeDist = false
+                     )
+      _ <- IO(assertEquals(storeCount1, 3L))
+      storedMembers1 <- redis.zRange("location-store-1", 0, -1)
+      _ <- IO(assertEquals(storedMembers1.toSet, byCoordRadius))
+
+      // geoSearchStore: FromCoordinates, storeDist = true
+      storeCount2 <- redis.geoSearchStore(
+                       "location-store-2",
+                       testKey,
+                       GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
+                       GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
+                       storeDist = true
+                     )
+      _ <- IO(assertEquals(storeCount2, 3L))
+
+      // geoSearchStore: FromMember, storeDist = false, with GeoArgs (count = 1)
+      storeCount3 <- redis.geoSearchStore(
+                       "location-store-3",
+                       testKey,
+                       GeoSearchReference.FromMember(_Montevideo.value),
+                       GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
+                       storeDist = false,
+                       new GeoArgs().withCount(1)
+                     )
+      _ <- IO(assertEquals(storeCount3, 1L))
+
+      // geoSearchStore: FromMember, storeDist = true
+      storeCount4 <- redis.geoSearchStore(
+                       "location-store-4",
+                       testKey,
+                       GeoSearchReference.FromMember(_Montevideo.value),
+                       GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km),
+                       storeDist = true
+                     )
+      _ <- IO(assertEquals(storeCount4, 3L))
+
+      // geoSearchStore: empty result stores nothing
+      storeCountEmpty <- redis.geoSearchStore(
+                           "location-store-empty",
+                           testKey,
+                           GeoSearchReference.FromCoordinates(Longitude(0.0), Latitude(0.0)),
+                           GeoSearchPredicate.ByRadius(Distance(1.0), GeoArgs.Unit.km),
+                           storeDist = false
+                         )
+      _ <- IO(assertEquals(storeCountEmpty, 0L))
     } yield ()
   }
 

--- a/site/docs/effects/geo.md
+++ b/site/docs/effects/geo.md
@@ -53,7 +53,11 @@ commandsApi.use { redis => // GeoCommands[IO, String, String]
     _ <- putStrLn(s"Distance from ${_BuenosAires.value} to Tokyo: $x km")
     y <- redis.geoPos(testKey, _RioDeJaneiro.value)
     _ <- putStrLn(s"Geo Pos of ${_RioDeJaneiro.value}: ${y.headOption}")
-    z <- redis.geoRadius(testKey, GeoRadius(_Montevideo.lon, _Montevideo.lat, Distance(10000.0)), GeoArgs.Unit.km)
+    z <- redis.geoSearch(
+           testKey,
+           GeoSearchReference.FromCoordinates(_Montevideo.lon, _Montevideo.lat),
+           GeoSearchPredicate.ByRadius(Distance(10000.0), GeoArgs.Unit.km)
+         )
     _ <- putStrLn(s"Geo Radius in 1000 km: $z")
   } yield ()
 }


### PR DESCRIPTION
## Summary

3.0.0 API redesign for redis4cats' Geo, List, and Hash commands, plus a
"never discard information the underlying Lettuce call already provides"
audit across the whole command surface. Full design rationale:
`docs/superpowers/specs/2026-09-02-geo-list-hash-api-redesign-design.md`
(not committed — local planning artifact per project convention).

### Breaking changes

- **Removed** `hmSet` (long-`@deprecated` since 1.0.1; superseded by
  `hSet(key, Map): F[Long]`, which already existed and already returns a
  richer result).
- **Removed** `geoRadius`/`geoRadiusByMember` (8 overloads), `GeoRadius`,
  `GeoRadiusKeyStorage`, `GeoRadiusDistStorage` — replaced by a unified
  `geoSearch`/`geoSearchStore` pair built on new `GeoSearchReference`
  (`FromCoordinates`/`FromMember`) and `GeoSearchPredicate`
  (`ByRadius`/`ByBox`) ADTs, modeled on Redis's own `GEOSEARCH`/
  `GEOSEARCHSTORE` (which Redis introduced specifically to replace
  `GEORADIUS`/`GEORADIUSBYMEMBER`, and which adds box-shaped search — a
  capability `GEORADIUS` never had).
- **Return type changed `F[Unit]` → `F[Long]`** (the count/length Lettuce's
  command already computes, previously discarded): `bitOpAnd`, `bitOpNot`,
  `bitOpOr`, `bitOpXor`, `geoAdd`, `sUnionStore`, `append`, `setRange`.
  `geoSearchStore` also returns `F[Long]`.
- **`GeoRadiusResult` renamed to `GeoSearchResult`**, with `dist`/`hash`/
  `coordinate` now `Option`-typed instead of silently unsafe — each is
  `None` unless the producing `geoSearch` call's `GeoArgs` requested that
  flag, matching Lettuce's own `GeoWithin` contract ("if requested,
  otherwise null") instead of assuming the values are always present.
- **`geoSearchStore`'s `args` parameter is now `GeoStoreArgs(count, sort)`**
  instead of a raw `GeoArgs` — it can no longer be used to express state
  `GEOSEARCHSTORE` actually rejects (`WITHDIST`/`WITHHASH`/`WITHCOORD`,
  which only apply to `GEOSEARCH`).

### New capability

- General `lMove`/`blMove` (all 4 source/destination side combinations via
  a new `LMoveSide` ADT), alongside the existing `rPopLPush`/`brPopLPush`
  sugar (unchanged — still the common right→left case).

### A deliberate, documented risk acceptance

`geoSearch`/`geoSearchStore` dispatch uniformly through Lettuce's real
`GEOSEARCH`/`GEOSEARCHSTORE`, **including for member-based references**.
Lettuce's `GeoSearch.fromMember[K]` is mistyped upstream (Lettuce's own
source: `// TODO: Should be V`) and encodes the member with the *key*
codec instead of the *value* codec — for a `RedisCodec[K, V]` with
distinct K/V types, this could miscode the member on the wire. This is
the identical class of bug reported and fixed for `ZINCRBY` years ago
(redis/lettuce#826), just never caught here. We chose to accept this as
Lettuce's bug rather than fall back to the deprecated `georadiusbymember`
for member-based search, because that legacy command never supported
box-shaped search at all — a fallback would have left `FromMember`+`ByBox`
with no implementation whatsoever. See the comment at the `toGeoRef` call
site in `redis.scala` for the full analysis.

As a side effect of this rewrite, `geoSearchStore` now uses the
cluster-safe `async` accessor (matching every other geo/data command in
this file) instead of the old `geoRadius(...,storage)` methods'
inconsistent direct use of `conn.async`, which bypassed cluster routing.

### Also removed

The now-dead `-Wconf:cat=deprecation&origin=io\.lettuce\..*:s` rule added
in #1179 — nothing in the codebase calls a Lettuce-deprecated method
anymore after this PR.

## Test plan

- [x] `sbt compile` + `Test/compile` across all modules — clean, zero warnings
- [x] `sbt mdoc` — clean (independently verified; local module compiles alone don't catch mdoc-processed doc snippets referencing removed APIs)
- [x] `sbt mimaReportBinaryIssuesIfRelevant` — no-op (no previous 3.0.0 artifacts published yet)
- [x] Exhaustive new/changed test coverage added to `TestScenarios.scala`: full `GeoSearchReference` × `GeoSearchPredicate` matrix (including the `FromMember`+`ByBox` combination that has no legacy fallback), all 4 `lMove`/`blMove` direction combinations plus edge cases, concrete-count assertions for every `F[Unit]`→`F[Long]` change (including a BITOP different-source-length case verifying real Redis semantics), `hSet`'s `F[Long]` return now asserted
- [x] New multi-key test additions hash-tag-scoped (`{listmove}:`, `{sunion}:`, `{geosearch}:`) for correctness under `RedisClusterSpec`'s real 6-node cluster suite
- [ ] CI integration tests against real Redis (single-node and cluster) — can't run locally here (no local Redis instance available in this environment); this is exactly what CI's `docker compose`-based suite verifies