### PR TITLE
series/3.x: add SCRIPT KILL

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -39,6 +39,7 @@ trait Scripting[F[_], K, V] {
   def scriptLoad(script: Array[Byte]): F[String]
   def scriptExists(digests: String*): F[List[Boolean]]
   def scriptFlush: F[Unit]
+  def scriptKill(): F[String]
   def digest(script: String): F[String]
 }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/scripts.scala
@@ -39,7 +39,7 @@ trait Scripting[F[_], K, V] {
   def scriptLoad(script: Array[Byte]): F[String]
   def scriptExists(digests: String*): F[List[Boolean]]
   def scriptFlush: F[Unit]
-  def scriptKill(): F[String]
+  def scriptKill: F[String]
   def digest(script: String): F[String]
 }
 

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1941,7 +1941,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def scriptFlush: F[Unit] =
     async.flatMap(_.scriptFlush().futureLift.void)
 
-  override def scriptKill(): F[String] =
+  override def scriptKill: F[String] =
     async.flatMap(_.scriptKill().futureLift)
 
   override def digest(script: String): F[String] =

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1941,6 +1941,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def scriptFlush: F[Unit] =
     async.flatMap(_.scriptFlush().futureLift.void)
 
+  override def scriptKill(): F[String] =
+    async.flatMap(_.scriptKill().futureLift)
+
   override def digest(script: String): F[String] =
     async.map(_.digest(script))
 

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -1078,7 +1078,7 @@ trait TestScenarios { self: FunSuite =>
       // SCRIPT KILL only succeeds while a script is actually blocking the server; with nothing
       // running, Redis rejects it — that's the realistic case to assert, not a happy path we can't
       // safely trigger from a single-threaded test without actually hanging the server.
-      killAttempt <- redis.scriptKill().attempt
+      killAttempt <- redis.scriptKill.attempt
       _ <- IO(
              assert(
                killAttempt.left.exists { ex =>

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -1075,6 +1075,18 @@ trait TestScenarios { self: FunSuite =>
       _ <- redis.scriptFlush
       exists2 <- redis.scriptExists(sha42)
       _ <- IO(assertEquals(exists2, List(false)))
+      // SCRIPT KILL only succeeds while a script is actually blocking the server; with nothing
+      // running, Redis rejects it — that's the realistic case to assert, not a happy path we can't
+      // safely trigger from a single-threaded test without actually hanging the server.
+      killAttempt <- redis.scriptKill().attempt
+      _ <- IO(
+             assert(
+               killAttempt.left.exists { ex =>
+                 ex.isInstanceOf[RedisCommandExecutionException] &&
+                 ex.getMessage.startsWith("NOTBUSY")
+               }
+             )
+           )
     } yield ()
   }
 


### PR DESCRIPTION
## Summary

Closes a small command-coverage gap: `scripts.scala` had `scriptFlush`,
`scriptExists`, `scriptLoad`, `digest`, and the whole Functions family
(`functionKill`, etc.), but no `SCRIPT KILL` — the operationally
important safety-valve for stopping a currently-running Lua script.

`scriptKill(): F[String]` returns the raw status string, matching this
file's existing `functionKill(): F[String]` convention for admin
"kill"-style commands, rather than `F[Unit]` — both are ack-only
commands, and the direct precedent already in this file settled which
shape to use.

## Test plan

- [x] `sbt compile` + `Test/compile` across all modules — clean, zero warnings
- [x] `sbt mdoc` — clean
- [x] Test exercises the realistic case: `SCRIPT KILL` only succeeds
      while a script is actually blocking the server, so calling it with
      nothing running is expected to fail with `NOTBUSY`, asserted via
      `.attempt`/`isLeft` rather than a vacuous "doesn't throw" check
- [ ] CI integration test against real Redis — can't run locally here (no
      local Redis instance available in this environment)