### PR TITLE
series/3.x: close hashes command gap (HSETEX, HRANDFIELD)

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/hashes.scala
@@ -17,7 +17,7 @@
 package dev.profunktor.redis4cats.algebra
 
 import dev.profunktor.redis4cats.data.{ KeyScanCursor, MapScanCursor }
-import dev.profunktor.redis4cats.effects.{ ExpireExistenceArg, HGetExArgs, ScanArgs }
+import dev.profunktor.redis4cats.effects.{ ExpireExistenceArg, HGetExArgs, HSetExArgs, ScanArgs }
 
 import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
@@ -48,12 +48,30 @@ trait HashGetter[F[_], K, V] {
   def hScanNoValues(key: K, cursor: KeyScanCursor[K]): F[KeyScanCursor[K]]
   def hScanNoValues(key: K, scanArgs: ScanArgs): F[KeyScanCursor[K]]
   def hScanNoValues(key: K, cursor: KeyScanCursor[K], scanArgs: ScanArgs): F[KeyScanCursor[K]]
+
+  /** Returns a single random field from the hash, or `None` if the hash doesn't exist. */
+  def hRandField(key: K): F[Option[K]]
+
+  /** Returns up to `count` random fields from the hash (fewer than `count` distinct fields, or duplicates if `count` is
+    * negative — see HRANDFIELD's own semantics for the exact behavior).
+    */
+  def hRandField(key: K, count: Long): F[List[K]]
+
+  /** Returns a single random field-value pair from the hash, or `None` if the hash doesn't exist. */
+  def hRandFieldWithValues(key: K): F[Option[(K, V)]]
+
+  /** Returns up to `count` random field-value pairs from the hash. */
+  def hRandFieldWithValues(key: K, count: Long): F[List[(K, V)]]
 }
 
 trait HashSetter[F[_], K, V] {
   def hSet(key: K, field: K, value: V): F[Boolean]
   def hSet(key: K, fieldValues: Map[K, V]): F[Long]
   def hSetNx(key: K, field: K, value: V): F[Boolean]
+
+  /** HSETEX: set one or more fields with an optional TTL and/or field-existence condition, atomically. */
+  def hSetEx(key: K, fieldValues: Map[K, V]): F[Long]
+  def hSetEx(key: K, args: HSetExArgs, fieldValues: Map[K, V]): F[Long]
 }
 
 trait HashExpire[F[_], K] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -466,6 +466,44 @@ object effects {
     def apply(ex: SetArg.Existence, ttl: SetArg.Ttl): SetArgs = SetArgs(Some(ex), Some(ttl))
   }
 
+  sealed trait HSetExArg
+  object HSetExArg {
+    sealed trait Existence extends HSetExArg
+    object Existence {
+
+      /** Only set fields that do not already exist (FNX) */
+      case object Nx extends Existence
+
+      /** Only set fields that already exist (FXX) */
+      case object Xx extends Existence
+    }
+
+    sealed trait Ttl extends HSetExArg
+    object Ttl {
+
+      /** Set expiration in seconds, relative */
+      case class Ex(duration: FiniteDuration) extends Ttl
+
+      /** Set expiration in millis, relative */
+      case class Px(duration: FiniteDuration) extends Ttl
+
+      /** Set expiration at an absolute time, second precision */
+      case class ExAt(at: Instant) extends Ttl
+
+      /** Set expiration at an absolute time, millisecond precision */
+      case class PxAt(at: Instant) extends Ttl
+
+      /** Retain the fields' existing TTL */
+      case object Keep extends Ttl
+    }
+  }
+  case class HSetExArgs(existence: Option[HSetExArg.Existence] = None, ttl: Option[HSetExArg.Ttl] = None)
+  object HSetExArgs {
+    def apply(ex: HSetExArg.Existence): HSetExArgs                     = HSetExArgs(Some(ex), None)
+    def apply(ttl: HSetExArg.Ttl): HSetExArgs                          = HSetExArgs(None, Some(ttl))
+    def apply(ex: HSetExArg.Existence, ttl: HSetExArg.Ttl): HSetExArgs = HSetExArgs(Some(ex), Some(ttl))
+  }
+
   sealed trait LMoveSide
   object LMoveSide {
     case object Left extends LMoveSide

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -50,6 +50,7 @@ import io.lettuce.core.{
   GeoWithin,
   GetExArgs => JGetExArgs,
   HGetExArgs => JHGetExArgs,
+  HSetExArgs => JHSetExArgs,
   LMoveArgs,
   Limit => JLimit,
   Range => JRange,
@@ -1001,6 +1002,20 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def hScanNoValues(key: K, cursor: KeyScanCursor[K], scanArgs: ScanArgs): F[KeyScanCursor[K]] =
     async.flatMap(_.hscanNovalues(key, cursor.underlying, scanArgs.underlying).futureLift.map(KeyScanCursor[K](_)))
 
+  override def hRandField(key: K): F[Option[K]] =
+    async.flatMap(_.hrandfield(key).futureLift.map(Option.apply))
+
+  override def hRandField(key: K, count: Long): F[List[K]] =
+    async.flatMap(_.hrandfield(key, count).futureLift.map(_.asScala.toList))
+
+  override def hRandFieldWithValues(key: K): F[Option[(K, V)]] =
+    async.flatMap(_.hrandfieldWithvalues(key).futureLift.map(kv => Option(kv).map(kv => kv.getKey -> kv.getValue)))
+
+  override def hRandFieldWithValues(key: K, count: Long): F[List[(K, V)]] =
+    async.flatMap(
+      _.hrandfieldWithvalues(key, count).futureLift.map(_.asScala.toList.map(kv => kv.getKey -> kv.getValue))
+    )
+
   override def hSet(key: K, field: K, value: V): F[Boolean] =
     async.flatMap(_.hset(key, field, value).futureLift.map(x => Boolean.box(x)))
 
@@ -1065,6 +1080,28 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def hSetNx(key: K, field: K, value: V): F[Boolean] =
     async.flatMap(_.hsetnx(key, field, value).futureLift.map(x => Boolean.box(x)))
+
+  override def hSetEx(key: K, fieldValues: Map[K, V]): F[Long] =
+    async.flatMap(_.hsetex(key, fieldValues.asJava).futureLift.map(x => Long.box(x)))
+
+  override def hSetEx(key: K, args: HSetExArgs, fieldValues: Map[K, V]): F[Long] = {
+    val jArgs = new JHSetExArgs()
+
+    args.existence.foreach {
+      case HSetExArg.Existence.Nx => jArgs.fnx()
+      case HSetExArg.Existence.Xx => jArgs.fxx()
+    }
+
+    args.ttl.foreach {
+      case HSetExArg.Ttl.Ex(d)    => jArgs.ex(java.time.Duration.ofMillis(d.toMillis))
+      case HSetExArg.Ttl.Px(d)    => jArgs.px(java.time.Duration.ofMillis(d.toMillis))
+      case HSetExArg.Ttl.ExAt(at) => jArgs.exAt(at)
+      case HSetExArg.Ttl.PxAt(at) => jArgs.pxAt(at)
+      case HSetExArg.Ttl.Keep     => jArgs.keepttl()
+    }
+
+    async.flatMap(_.hsetex(key, jArgs, fieldValues.asJava).futureLift.map(x => Long.box(x)))
+  }
 
   override def hIncrBy(key: K, field: K, amount: Long): F[Long] =
     async.flatMap(_.hincrby(key, field, amount).futureLift.map(x => Long.box(x)))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -283,6 +283,40 @@ trait TestScenarios { self: FunSuite =>
           (hScanKey, ScanArgs("*r*", count = 5L))
         ) { case (k, a) => redis.hScanNoValues(k, a) } { case ((k, a), c) => redis.hScanNoValues(k, c, a) }
       _ <- IO(assertEquals(hScanNovResR.toSet, hScanMapR.keySet))
+      // hRandField / hRandFieldWithValues
+      hRandKey    = "hrand-test"
+      hRandFields = Map("a" -> "1", "b" -> "2", "c" -> "3")
+      _ <- redis.hSet(hRandKey, hRandFields)
+      oneField <- redis.hRandField(hRandKey)
+      _ <- IO(assert(oneField.exists(hRandFields.keySet.contains)))
+      allFields <- redis.hRandField(hRandKey, 3)
+      _ <- IO(assertEquals(allFields.toSet, hRandFields.keySet))
+      _ <- IO(assertEquals(allFields.distinct.size, 3)) // count == cardinality, no repeats
+      onePair <- redis.hRandFieldWithValues(hRandKey)
+      _ <- IO(assert(onePair.exists { case (k, v) => hRandFields.get(k).contains(v) }))
+      allPairs <- redis.hRandFieldWithValues(hRandKey, 3)
+      _ <- IO(assertEquals(allPairs.toMap, hRandFields))
+      missingField <- redis.hRandField("hrand-does-not-exist")
+      _ <- IO(assertEquals(missingField, None))
+      missingFieldList <- redis.hRandField("hrand-does-not-exist", 3)
+      _ <- IO(assert(missingFieldList.isEmpty))
+      missingPair <- redis.hRandFieldWithValues("hrand-does-not-exist")
+      _ <- IO(assertEquals(missingPair, None))
+      // hSetEx: plain (no args), and with existence/TTL args
+      hSetExKey = "hsetex-test"
+      hSetExPlain <- redis.hSetEx(hSetExKey, Map("x" -> "1", "y" -> "2"))
+      _ <- IO(assertEquals(hSetExPlain, 1L)) // whole-operation success status, not a per-field count
+      hSetExVal <- redis.hGet(hSetExKey, "x")
+      _ <- IO(assertEquals(hSetExVal, Some("1")))
+      hSetExNxFirst <- redis.hSetEx(hSetExKey, HSetExArgs(HSetExArg.Existence.Nx), Map("z" -> "3"))
+      _ <- IO(assertEquals(hSetExNxFirst, 1L)) // "z" didn't exist yet, condition satisfied
+      hSetExNxSecond <- redis.hSetEx(hSetExKey, HSetExArgs(HSetExArg.Existence.Nx), Map("z" -> "should-not-apply"))
+      _ <- IO(assertEquals(hSetExNxSecond, 0L)) // "z" now exists, FNX condition fails
+      hSetExUnchangedVal <- redis.hGet(hSetExKey, "z")
+      _ <- IO(assertEquals(hSetExUnchangedVal, Some("3")))
+      _ <- redis.hSetEx(hSetExKey, HSetExArgs(HSetExArg.Ttl.Ex(10.seconds)), Map("withTtl" -> "value"))
+      hSetExTtl <- redis.httl(hSetExKey, "withTtl")
+      _ <- IO(assert(hSetExTtl.forall(_.exists(_ > 0.seconds))))
     } yield ()
   }
 


### PR DESCRIPTION
## Summary

Part of a broader command-coverage audit against Lettuce 7.7.0. Closes
the gap for `algebra/hashes.scala`:

- **`hSetEx`** (new) — wraps `HSETEX` (Redis 8.0+), which atomically sets
  one or more hash fields with a shared TTL and/or field-existence
  condition (FNX/FXX). Returns `F[Long]` — a whole-operation success
  status (1/0), not a per-field count, since HSETEX is all-or-nothing
  across the given fields (unlike plain `HSET`, which is per-field and
  returns the count of new fields). New `HSetExArgs`/`HSetExArg` types in
  `effects.scala` mirror the existing `SetArgs`/`SetArg` composable shape
  (independent `existence` + `ttl` choices), with `HSetExArg.Ttl` covering
  the fuller `EX`/`PX`/`EXAT`/`PXAT`/`KEEPTTL` vocabulary HSETEX actually
  supports — matching `HGetExArgs`' existing vocabulary rather than
  `SetArg.Ttl`'s narrower `EX`/`PX`/`KEEP`.
- **`hRandField`/`hRandFieldWithValues`** (new) — wraps `HRANDFIELD`. Not
  a 7.7.0-specific gap, just a long-standing one.

**Skipped:** `himportSet` (`HIMPORT`). Its supporting `HashImport[K]` type
is a stateful, connection-pinned, explicitly-`Closeable` resource
(fieldset metadata is declared to the server on first use and must be
closed to release server-side state), not a plain immutable args value —
it doesn't fit redis4cats' per-call `F[A]` method style cleanly. This
looks like it wants a dedicated `Resource[F, HashImportHandle]`-shaped
API rather than a quick wrapper; leaving it for a separate design pass.

## Test plan

- [x] `sbt compile` + `Test/compile` across all modules — clean, zero warnings
- [x] `sbt mdoc` — clean
- [x] New coverage in `hashesScenario`: `hRandField`/`hRandFieldWithValues`
  (single and count-based, including the missing-key `None`/empty-list
  cases, and that a count equal to cardinality returns every field with no
  repeats), `hSetEx` (plain success status, FNX success-then-failure pair
  confirming the condition is enforced, and a TTL-setting case verified via
  `httl`)
- [ ] CI integration tests against real Redis — can't run locally here (no
  local Redis instance in this environment)