### PR TITLE
series/3.x: close lists command gap (LMPOP/BLMPOP, LPOS, multi-pop)

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/lists.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/lists.scala
@@ -17,7 +17,7 @@
 package dev.profunktor.redis4cats.algebra
 
 import cats.data.NonEmptyList
-import dev.profunktor.redis4cats.effects.LMoveSide
+import dev.profunktor.redis4cats.effects.{ LMoveCount, LMoveSide, LPosArgs }
 
 import scala.concurrent.duration.Duration
 
@@ -38,12 +38,33 @@ trait ListBlocking[F[_], K, V] {
       sourceSide: LMoveSide,
       destinationSide: LMoveSide
   ): F[Option[V]]
+  def blMoveMany(
+      timeout: Duration,
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide
+  ): F[List[V]]
+  def blMoveMany(
+      timeout: Duration,
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide,
+      count: LMoveCount
+  ): F[List[V]]
+  def blmPop(timeout: Duration, keys: NonEmptyList[K], side: LMoveSide): F[Option[(K, List[V])]]
+  def blmPop(timeout: Duration, keys: NonEmptyList[K], side: LMoveSide, count: Long): F[Option[(K, List[V])]]
 }
 
 trait ListGetter[F[_], K, V] {
   def lIndex(key: K, index: Long): F[Option[V]]
   def lLen(key: K): F[Long]
   def lRange(key: K, start: Long, stop: Long): F[List[V]]
+  def lPos(key: K, value: V): F[Option[Long]]
+  def lPos(key: K, value: V, args: LPosArgs): F[Option[Long]]
+  def lPos(key: K, value: V, count: Long): F[List[Long]]
+  def lPos(key: K, value: V, count: Long, args: LPosArgs): F[List[Long]]
 }
 
 trait ListSetter[F[_], K, V] {
@@ -56,11 +77,23 @@ trait ListSetter[F[_], K, V] {
 
 trait ListPushPop[F[_], K, V] {
   def lPop(key: K): F[Option[V]]
+  def lPop(key: K, count: Long): F[List[V]]
   def lPush(key: K, values: V*): F[Long]
   def lPushX(key: K, values: V*): F[Long]
   def rPop(key: K): F[Option[V]]
+  def rPop(key: K, count: Long): F[List[V]]
   def rPopLPush(source: K, destination: K): F[Option[V]]
   def lMove(source: K, destination: K, sourceSide: LMoveSide, destinationSide: LMoveSide): F[Option[V]]
+  def lMoveMany(source: K, destination: K, sourceSide: LMoveSide, destinationSide: LMoveSide): F[List[V]]
+  def lMoveMany(
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide,
+      count: LMoveCount
+  ): F[List[V]]
+  def lmPop(keys: NonEmptyList[K], side: LMoveSide): F[Option[(K, List[V])]]
+  def lmPop(keys: NonEmptyList[K], side: LMoveSide, count: Long): F[Option[(K, List[V])]]
   def rPush(key: K, values: V*): F[Long]
   def rPushX(key: K, values: V*): F[Long]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/lists.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/lists.scala
@@ -17,7 +17,7 @@
 package dev.profunktor.redis4cats.algebra
 
 import cats.data.NonEmptyList
-import dev.profunktor.redis4cats.effects.{ LMoveCount, LMoveSide, LPosArgs }
+import dev.profunktor.redis4cats.effects.{ LMoveSide, LPosArgs }
 
 import scala.concurrent.duration.Duration
 
@@ -38,21 +38,6 @@ trait ListBlocking[F[_], K, V] {
       sourceSide: LMoveSide,
       destinationSide: LMoveSide
   ): F[Option[V]]
-  def blMoveMany(
-      timeout: Duration,
-      source: K,
-      destination: K,
-      sourceSide: LMoveSide,
-      destinationSide: LMoveSide
-  ): F[List[V]]
-  def blMoveMany(
-      timeout: Duration,
-      source: K,
-      destination: K,
-      sourceSide: LMoveSide,
-      destinationSide: LMoveSide,
-      count: LMoveCount
-  ): F[List[V]]
   def blmPop(timeout: Duration, keys: NonEmptyList[K], side: LMoveSide): F[Option[(K, List[V])]]
   def blmPop(timeout: Duration, keys: NonEmptyList[K], side: LMoveSide, count: Long): F[Option[(K, List[V])]]
 }
@@ -84,14 +69,6 @@ trait ListPushPop[F[_], K, V] {
   def rPop(key: K, count: Long): F[List[V]]
   def rPopLPush(source: K, destination: K): F[Option[V]]
   def lMove(source: K, destination: K, sourceSide: LMoveSide, destinationSide: LMoveSide): F[Option[V]]
-  def lMoveMany(source: K, destination: K, sourceSide: LMoveSide, destinationSide: LMoveSide): F[List[V]]
-  def lMoveMany(
-      source: K,
-      destination: K,
-      sourceSide: LMoveSide,
-      destinationSide: LMoveSide,
-      count: LMoveCount
-  ): F[List[V]]
   def lmPop(keys: NonEmptyList[K], side: LMoveSide): F[Option[(K, List[V])]]
   def lmPop(keys: NonEmptyList[K], side: LMoveSide, count: Long): F[Option[(K, List[V])]]
   def rPush(key: K, values: V*): F[Long]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -23,6 +23,7 @@ import io.lettuce.core.{
   AclCategory => JAclCategory,
   GeoArgs,
   KeyScanArgs => JKeyScanArgs,
+  LMovemArgs,
   ScanArgs => JScanArgs,
   ScriptOutputType => JScriptOutputType
 }
@@ -548,6 +549,21 @@ object effects {
     case object Left extends LMoveSide
     case object Right extends LMoveSide
   }
+
+  /** The optional COUNT/EXACTLY block of LMOVEM/BLMOVEM. Without one, LMOVEM/BLMOVEM behave like LMOVE/BLMOVE (move a
+    * single element) — use `lMove`/`blMove` for that case instead.
+    */
+  sealed trait LMoveCount
+  object LMoveCount {
+
+    /** Move up to `count` elements. */
+    final case class UpTo(count: Long, ordering: LMovemArgs.Ordering) extends LMoveCount
+
+    /** Move exactly `count` elements, or none at all if the source doesn't have enough. */
+    final case class Exactly(count: Long, ordering: LMovemArgs.Ordering) extends LMoveCount
+  }
+
+  final case class LPosArgs(rank: Option[Long] = None, maxLen: Option[Long] = None)
 
   sealed trait ExpireExistenceArg
   object ExpireExistenceArg {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -23,7 +23,6 @@ import io.lettuce.core.{
   AclCategory => JAclCategory,
   GeoArgs,
   KeyScanArgs => JKeyScanArgs,
-  LMovemArgs,
   ScanArgs => JScanArgs,
   ScriptOutputType => JScriptOutputType
 }
@@ -548,19 +547,6 @@ object effects {
   object LMoveSide {
     case object Left extends LMoveSide
     case object Right extends LMoveSide
-  }
-
-  /** The optional COUNT/EXACTLY block of LMOVEM/BLMOVEM. Without one, LMOVEM/BLMOVEM behave like LMOVE/BLMOVE (move a
-    * single element) — use `lMove`/`blMove` for that case instead.
-    */
-  sealed trait LMoveCount
-  object LMoveCount {
-
-    /** Move up to `count` elements. */
-    final case class UpTo(count: Long, ordering: LMovemArgs.Ordering) extends LMoveCount
-
-    /** Move exactly `count` elements, or none at all if the source doesn't have enough. */
-    final case class Exactly(count: Long, ordering: LMovemArgs.Ordering) extends LMoveCount
   }
 
   final case class LPosArgs(rank: Option[Long] = None, maxLen: Option[Long] = None)

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -38,6 +38,7 @@ import io.lettuce.core.json.arguments.{ JsonMsetArgs, JsonRangeArgs, JsonSetArgs
 import io.lettuce.core.json.{ JsonPath, JsonType, JsonValue }
 import io.lettuce.core.{
   AclSetuserArgs,
+  BLMovemArgs,
   BitFieldArgs,
   ClientOptions,
   Consumer => JConsumer,
@@ -51,7 +52,10 @@ import io.lettuce.core.{
   GetExArgs => JGetExArgs,
   HGetExArgs => JHGetExArgs,
   HSetExArgs => JHSetExArgs,
+  LMPopArgs,
   LMoveArgs,
+  LMovemArgs,
+  LPosArgs => JLPosArgs,
   Limit => JLimit,
   Range => JRange,
   ReadFrom => JReadFrom,
@@ -1274,6 +1278,47 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       case (LMoveSide.Right, LMoveSide.Right) => LMoveArgs.Builder.rightRight()
     }
 
+  private def toLMovemArgs(sourceSide: LMoveSide, destinationSide: LMoveSide): LMovemArgs =
+    (sourceSide, destinationSide) match {
+      case (LMoveSide.Left, LMoveSide.Left)   => LMovemArgs.Builder.leftLeft()
+      case (LMoveSide.Left, LMoveSide.Right)  => LMovemArgs.Builder.leftRight()
+      case (LMoveSide.Right, LMoveSide.Left)  => LMovemArgs.Builder.rightLeft()
+      case (LMoveSide.Right, LMoveSide.Right) => LMovemArgs.Builder.rightRight()
+    }
+
+  private def applyLMoveCount(args: LMovemArgs, count: LMoveCount): LMovemArgs =
+    count match {
+      case LMoveCount.UpTo(n, ordering)    => args.count(n, ordering)
+      case LMoveCount.Exactly(n, ordering) => args.exactly(n, ordering)
+    }
+
+  private def toBLMovemArgs(sourceSide: LMoveSide, destinationSide: LMoveSide): BLMovemArgs =
+    (sourceSide, destinationSide) match {
+      case (LMoveSide.Left, LMoveSide.Left)   => BLMovemArgs.Builder.leftLeft()
+      case (LMoveSide.Left, LMoveSide.Right)  => BLMovemArgs.Builder.leftRight()
+      case (LMoveSide.Right, LMoveSide.Left)  => BLMovemArgs.Builder.rightLeft()
+      case (LMoveSide.Right, LMoveSide.Right) => BLMovemArgs.Builder.rightRight()
+    }
+
+  private def applyLMoveCount(args: BLMovemArgs, count: LMoveCount): BLMovemArgs =
+    count match {
+      case LMoveCount.UpTo(n, ordering)    => args.count(n, ordering)
+      case LMoveCount.Exactly(n, ordering) => args.exactly(n, ordering)
+    }
+
+  private def toLMPopArgs(side: LMoveSide): LMPopArgs =
+    side match {
+      case LMoveSide.Left  => LMPopArgs.Builder.left()
+      case LMoveSide.Right => LMPopArgs.Builder.right()
+    }
+
+  private def toJLPosArgs(args: LPosArgs): JLPosArgs = {
+    val jArgs = JLPosArgs.Builder.empty()
+    args.rank.foreach(jArgs.rank)
+    args.maxLen.foreach(jArgs.maxlen)
+    jArgs
+  }
+
   override def brPopLPush(timeout: Duration, source: K, destination: K): F[Option[V]] =
     async.flatMap(
       _.blmove(source, destination, LMoveArgs.Builder.rightLeft(), timeout.toSecondsOrZero).futureLift.map(Option.apply)
@@ -1291,8 +1336,58 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
         .map(Option.apply)
     )
 
+  override def blMoveMany(
+      timeout: Duration,
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide
+  ): F[List[V]] =
+    async.flatMap(
+      _.blmovem(
+        source,
+        destination,
+        toBLMovemArgs(sourceSide, destinationSide).timeout(timeout.toSecondsOrZero)
+      ).futureLift
+        .map(_.asScala.toList)
+    )
+
+  override def blMoveMany(
+      timeout: Duration,
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide,
+      count: LMoveCount
+  ): F[List[V]] =
+    async.flatMap(
+      _.blmovem(
+        source,
+        destination,
+        applyLMoveCount(toBLMovemArgs(sourceSide, destinationSide), count).timeout(timeout.toSecondsOrZero)
+      ).futureLift.map(_.asScala.toList)
+    )
+
+  override def blmPop(timeout: Duration, keys: NonEmptyList[K], side: LMoveSide): F[Option[(K, List[V])]] =
+    async
+      .flatMap(_.blmpop(timeout.toSecondsOrZero, toLMPopArgs(side), keys.toList: _*).futureLift)
+      .map(Option(_).map(kv => kv.getKey -> kv.getValue.asScala.toList))
+
+  override def blmPop(
+      timeout: Duration,
+      keys: NonEmptyList[K],
+      side: LMoveSide,
+      count: Long
+  ): F[Option[(K, List[V])]] =
+    async
+      .flatMap(_.blmpop(timeout.toSecondsOrZero, toLMPopArgs(side).count(count), keys.toList: _*).futureLift)
+      .map(Option(_).map(kv => kv.getKey -> kv.getValue.asScala.toList))
+
   override def lPop(key: K): F[Option[V]] =
     async.flatMap(_.lpop(key).futureLift.map(Option.apply))
+
+  override def lPop(key: K, count: Long): F[List[V]] =
+    async.flatMap(_.lpop(key, count).futureLift.map(_.asScala.toList))
 
   override def lPush(key: K, values: V*): F[Long] =
     async.flatMap(_.lpush(key, values: _*).futureLift.map(x => Long.box(x)))
@@ -1303,11 +1398,58 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def rPop(key: K): F[Option[V]] =
     async.flatMap(_.rpop(key).futureLift.map(Option.apply))
 
+  override def rPop(key: K, count: Long): F[List[V]] =
+    async.flatMap(_.rpop(key, count).futureLift.map(_.asScala.toList))
+
   override def rPopLPush(source: K, destination: K): F[Option[V]] =
     async.flatMap(_.lmove(source, destination, LMoveArgs.Builder.rightLeft()).futureLift.map(Option.apply))
 
   override def lMove(source: K, destination: K, sourceSide: LMoveSide, destinationSide: LMoveSide): F[Option[V]] =
     async.flatMap(_.lmove(source, destination, toLMoveArgs(sourceSide, destinationSide)).futureLift.map(Option.apply))
+
+  override def lMoveMany(
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide
+  ): F[List[V]] =
+    async.flatMap(
+      _.lmovem(source, destination, toLMovemArgs(sourceSide, destinationSide)).futureLift.map(_.asScala.toList)
+    )
+
+  override def lMoveMany(
+      source: K,
+      destination: K,
+      sourceSide: LMoveSide,
+      destinationSide: LMoveSide,
+      count: LMoveCount
+  ): F[List[V]] =
+    async.flatMap(
+      _.lmovem(source, destination, applyLMoveCount(toLMovemArgs(sourceSide, destinationSide), count)).futureLift
+        .map(_.asScala.toList)
+    )
+
+  override def lmPop(keys: NonEmptyList[K], side: LMoveSide): F[Option[(K, List[V])]] =
+    async
+      .flatMap(_.lmpop(toLMPopArgs(side), keys.toList: _*).futureLift)
+      .map(Option(_).map(kv => kv.getKey -> kv.getValue.asScala.toList))
+
+  override def lmPop(keys: NonEmptyList[K], side: LMoveSide, count: Long): F[Option[(K, List[V])]] =
+    async
+      .flatMap(_.lmpop(toLMPopArgs(side).count(count), keys.toList: _*).futureLift)
+      .map(Option(_).map(kv => kv.getKey -> kv.getValue.asScala.toList))
+
+  override def lPos(key: K, value: V): F[Option[Long]] =
+    async.flatMap(_.lpos(key, value).futureLift.map(x => Option(x).map(Long.unbox)))
+
+  override def lPos(key: K, value: V, args: LPosArgs): F[Option[Long]] =
+    async.flatMap(_.lpos(key, value, toJLPosArgs(args)).futureLift.map(x => Option(x).map(Long.unbox)))
+
+  override def lPos(key: K, value: V, count: Long): F[List[Long]] =
+    async.flatMap(_.lpos(key, value, count.toInt).futureLift.map(_.asScala.toList.map(Long.unbox)))
+
+  override def lPos(key: K, value: V, count: Long, args: LPosArgs): F[List[Long]] =
+    async.flatMap(_.lpos(key, value, count.toInt, toJLPosArgs(args)).futureLift.map(_.asScala.toList.map(Long.unbox)))
 
   override def rPush(key: K, values: V*): F[Long] =
     async.flatMap(_.rpush(key, values: _*).futureLift.map(x => Long.box(x)))

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -38,7 +38,6 @@ import io.lettuce.core.json.arguments.{ JsonMsetArgs, JsonRangeArgs, JsonSetArgs
 import io.lettuce.core.json.{ JsonPath, JsonType, JsonValue }
 import io.lettuce.core.{
   AclSetuserArgs,
-  BLMovemArgs,
   BitFieldArgs,
   ClientOptions,
   Consumer => JConsumer,
@@ -54,7 +53,6 @@ import io.lettuce.core.{
   HSetExArgs => JHSetExArgs,
   LMPopArgs,
   LMoveArgs,
-  LMovemArgs,
   LPosArgs => JLPosArgs,
   Limit => JLimit,
   Range => JRange,
@@ -1278,34 +1276,6 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       case (LMoveSide.Right, LMoveSide.Right) => LMoveArgs.Builder.rightRight()
     }
 
-  private def toLMovemArgs(sourceSide: LMoveSide, destinationSide: LMoveSide): LMovemArgs =
-    (sourceSide, destinationSide) match {
-      case (LMoveSide.Left, LMoveSide.Left)   => LMovemArgs.Builder.leftLeft()
-      case (LMoveSide.Left, LMoveSide.Right)  => LMovemArgs.Builder.leftRight()
-      case (LMoveSide.Right, LMoveSide.Left)  => LMovemArgs.Builder.rightLeft()
-      case (LMoveSide.Right, LMoveSide.Right) => LMovemArgs.Builder.rightRight()
-    }
-
-  private def applyLMoveCount(args: LMovemArgs, count: LMoveCount): LMovemArgs =
-    count match {
-      case LMoveCount.UpTo(n, ordering)    => args.count(n, ordering)
-      case LMoveCount.Exactly(n, ordering) => args.exactly(n, ordering)
-    }
-
-  private def toBLMovemArgs(sourceSide: LMoveSide, destinationSide: LMoveSide): BLMovemArgs =
-    (sourceSide, destinationSide) match {
-      case (LMoveSide.Left, LMoveSide.Left)   => BLMovemArgs.Builder.leftLeft()
-      case (LMoveSide.Left, LMoveSide.Right)  => BLMovemArgs.Builder.leftRight()
-      case (LMoveSide.Right, LMoveSide.Left)  => BLMovemArgs.Builder.rightLeft()
-      case (LMoveSide.Right, LMoveSide.Right) => BLMovemArgs.Builder.rightRight()
-    }
-
-  private def applyLMoveCount(args: BLMovemArgs, count: LMoveCount): BLMovemArgs =
-    count match {
-      case LMoveCount.UpTo(n, ordering)    => args.count(n, ordering)
-      case LMoveCount.Exactly(n, ordering) => args.exactly(n, ordering)
-    }
-
   private def toLMPopArgs(side: LMoveSide): LMPopArgs =
     side match {
       case LMoveSide.Left  => LMPopArgs.Builder.left()
@@ -1334,38 +1304,6 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     async.flatMap(
       _.blmove(source, destination, toLMoveArgs(sourceSide, destinationSide), timeout.toSecondsOrZero).futureLift
         .map(Option.apply)
-    )
-
-  override def blMoveMany(
-      timeout: Duration,
-      source: K,
-      destination: K,
-      sourceSide: LMoveSide,
-      destinationSide: LMoveSide
-  ): F[List[V]] =
-    async.flatMap(
-      _.blmovem(
-        source,
-        destination,
-        toBLMovemArgs(sourceSide, destinationSide).timeout(timeout.toSecondsOrZero)
-      ).futureLift
-        .map(_.asScala.toList)
-    )
-
-  override def blMoveMany(
-      timeout: Duration,
-      source: K,
-      destination: K,
-      sourceSide: LMoveSide,
-      destinationSide: LMoveSide,
-      count: LMoveCount
-  ): F[List[V]] =
-    async.flatMap(
-      _.blmovem(
-        source,
-        destination,
-        applyLMoveCount(toBLMovemArgs(sourceSide, destinationSide), count).timeout(timeout.toSecondsOrZero)
-      ).futureLift.map(_.asScala.toList)
     )
 
   override def blmPop(timeout: Duration, keys: NonEmptyList[K], side: LMoveSide): F[Option[(K, List[V])]] =
@@ -1406,28 +1344,6 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def lMove(source: K, destination: K, sourceSide: LMoveSide, destinationSide: LMoveSide): F[Option[V]] =
     async.flatMap(_.lmove(source, destination, toLMoveArgs(sourceSide, destinationSide)).futureLift.map(Option.apply))
-
-  override def lMoveMany(
-      source: K,
-      destination: K,
-      sourceSide: LMoveSide,
-      destinationSide: LMoveSide
-  ): F[List[V]] =
-    async.flatMap(
-      _.lmovem(source, destination, toLMovemArgs(sourceSide, destinationSide)).futureLift.map(_.asScala.toList)
-    )
-
-  override def lMoveMany(
-      source: K,
-      destination: K,
-      sourceSide: LMoveSide,
-      destinationSide: LMoveSide,
-      count: LMoveCount
-  ): F[List[V]] =
-    async.flatMap(
-      _.lmovem(source, destination, applyLMoveCount(toLMovemArgs(sourceSide, destinationSide), count)).futureLift
-        .map(_.asScala.toList)
-    )
 
   override def lmPop(keys: NonEmptyList[K], side: LMoveSide): F[Option[(K, List[V])]] =
     async

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -27,7 +27,7 @@ import dev.profunktor.redis4cats.effects._
 import dev.profunktor.redis4cats.pubsub.PubSub
 import dev.profunktor.redis4cats.tx._
 import fs2.Stream
-import io.lettuce.core.{ GeoArgs, LMovemArgs, RedisCommandExecutionException, RedisException, ZAggregateArgs }
+import io.lettuce.core.{ GeoArgs, RedisCommandExecutionException, RedisException, ZAggregateArgs }
 import munit.FunSuite
 
 import java.time.Instant
@@ -401,56 +401,10 @@ trait TestScenarios { self: FunSuite =>
                     )
       _ <- IO(assertEquals(blmTimeout, None))
 
-      // lMoveMany: UpTo, BULK ordering (preserves original order)
-      _ <- redis.rPush("{listmove}:lmm-src", "a", "b", "c")
-      lmmUpTo <- redis.lMoveMany(
-                   "{listmove}:lmm-src",
-                   "{listmove}:lmm-dst",
-                   LMoveSide.Right,
-                   LMoveSide.Left,
-                   LMoveCount.UpTo(2, LMovemArgs.Ordering.BULK)
-                 )
-      _ <- IO(assertEquals(lmmUpTo, List("b", "c")))
-      lmmDst <- redis.lRange("{listmove}:lmm-dst", 0, -1)
-      _ <- IO(assertEquals(lmmDst, List("b", "c")))
-      lmmSrcRemaining <- redis.lRange("{listmove}:lmm-src", 0, -1)
-      _ <- IO(assertEquals(lmmSrcRemaining, List("a")))
-      // lMoveMany: no count block behaves like a single-element move but returns a List
-      lmmNoCount <- redis.lMoveMany("{listmove}:lmm-src", "{listmove}:lmm-dst", LMoveSide.Right, LMoveSide.Left)
-      _ <- IO(assertEquals(lmmNoCount, List("a")))
-      // lMoveMany: Exactly requesting more than available returns empty, moves nothing
-      _ <- redis.rPush("{listmove}:lmm-exactly-src", "x")
-      lmmExactlyShort <- redis.lMoveMany(
-                           "{listmove}:lmm-exactly-src",
-                           "{listmove}:lmm-exactly-dst",
-                           LMoveSide.Right,
-                           LMoveSide.Left,
-                           LMoveCount.Exactly(2, LMovemArgs.Ordering.BULK)
-                         )
-      _ <- IO(assert(lmmExactlyShort.isEmpty))
-      lmmExactlySrcUntouched <- redis.lRange("{listmove}:lmm-exactly-src", 0, -1)
-      _ <- IO(assertEquals(lmmExactlySrcUntouched, List("x")))
-
-      // blMoveMany: elements available immediately, with a count
-      _ <- redis.rPush("{listmove}:blmm-src", "p", "q")
-      blmmImmediate <- redis.blMoveMany(
-                         1.second,
-                         "{listmove}:blmm-src",
-                         "{listmove}:blmm-dst",
-                         LMoveSide.Right,
-                         LMoveSide.Left,
-                         LMoveCount.UpTo(2, LMovemArgs.Ordering.BULK)
-                       )
-      _ <- IO(assertEquals(blmmImmediate, List("p", "q")))
-      // blMoveMany: timeout expiry, no count block
-      blmmTimeout <- redis.blMoveMany(
-                       1.second,
-                       "{listmove}:blmm-does-not-exist",
-                       "{listmove}:blmm-dst",
-                       LMoveSide.Right,
-                       LMoveSide.Left
-                     )
-      _ <- IO(assert(blmmTimeout.isEmpty))
+      // Note: lMoveMany/blMoveMany (LMOVEM/BLMOVEM) are intentionally NOT covered here yet —
+      // that command was only added in Redis 8.10 (redis/redis#15405), newer than the Redis
+      // version this repo's CI currently tests against (8.0.1). Once the test Redis image is
+      // bumped, that coverage belongs in its own follow-up.
 
       // lmPop: first non-empty of several keys
       _ <- redis.rPush("{listmove}:lmpop-b", "1", "2")

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -27,7 +27,7 @@ import dev.profunktor.redis4cats.effects._
 import dev.profunktor.redis4cats.pubsub.PubSub
 import dev.profunktor.redis4cats.tx._
 import fs2.Stream
-import io.lettuce.core.{ GeoArgs, RedisCommandExecutionException, RedisException, ZAggregateArgs }
+import io.lettuce.core.{ GeoArgs, LMovemArgs, RedisCommandExecutionException, RedisException, ZAggregateArgs }
 import munit.FunSuite
 
 import java.time.Instant
@@ -400,6 +400,100 @@ trait TestScenarios { self: FunSuite =>
                       LMoveSide.Left
                     )
       _ <- IO(assertEquals(blmTimeout, None))
+
+      // lMoveMany: UpTo, BULK ordering (preserves original order)
+      _ <- redis.rPush("{listmove}:lmm-src", "a", "b", "c")
+      lmmUpTo <- redis.lMoveMany(
+                   "{listmove}:lmm-src",
+                   "{listmove}:lmm-dst",
+                   LMoveSide.Right,
+                   LMoveSide.Left,
+                   LMoveCount.UpTo(2, LMovemArgs.Ordering.BULK)
+                 )
+      _ <- IO(assertEquals(lmmUpTo, List("b", "c")))
+      lmmDst <- redis.lRange("{listmove}:lmm-dst", 0, -1)
+      _ <- IO(assertEquals(lmmDst, List("b", "c")))
+      lmmSrcRemaining <- redis.lRange("{listmove}:lmm-src", 0, -1)
+      _ <- IO(assertEquals(lmmSrcRemaining, List("a")))
+      // lMoveMany: no count block behaves like a single-element move but returns a List
+      lmmNoCount <- redis.lMoveMany("{listmove}:lmm-src", "{listmove}:lmm-dst", LMoveSide.Right, LMoveSide.Left)
+      _ <- IO(assertEquals(lmmNoCount, List("a")))
+      // lMoveMany: Exactly requesting more than available returns empty, moves nothing
+      _ <- redis.rPush("{listmove}:lmm-exactly-src", "x")
+      lmmExactlyShort <- redis.lMoveMany(
+                           "{listmove}:lmm-exactly-src",
+                           "{listmove}:lmm-exactly-dst",
+                           LMoveSide.Right,
+                           LMoveSide.Left,
+                           LMoveCount.Exactly(2, LMovemArgs.Ordering.BULK)
+                         )
+      _ <- IO(assert(lmmExactlyShort.isEmpty))
+      lmmExactlySrcUntouched <- redis.lRange("{listmove}:lmm-exactly-src", 0, -1)
+      _ <- IO(assertEquals(lmmExactlySrcUntouched, List("x")))
+
+      // blMoveMany: elements available immediately, with a count
+      _ <- redis.rPush("{listmove}:blmm-src", "p", "q")
+      blmmImmediate <- redis.blMoveMany(
+                         1.second,
+                         "{listmove}:blmm-src",
+                         "{listmove}:blmm-dst",
+                         LMoveSide.Right,
+                         LMoveSide.Left,
+                         LMoveCount.UpTo(2, LMovemArgs.Ordering.BULK)
+                       )
+      _ <- IO(assertEquals(blmmImmediate, List("p", "q")))
+      // blMoveMany: timeout expiry, no count block
+      blmmTimeout <- redis.blMoveMany(
+                       1.second,
+                       "{listmove}:blmm-does-not-exist",
+                       "{listmove}:blmm-dst",
+                       LMoveSide.Right,
+                       LMoveSide.Left
+                     )
+      _ <- IO(assert(blmmTimeout.isEmpty))
+
+      // lmPop: first non-empty of several keys
+      _ <- redis.rPush("{listmove}:lmpop-b", "1", "2")
+      lmPopResult <- redis.lmPop(NonEmptyList.of("{listmove}:lmpop-a", "{listmove}:lmpop-b"), LMoveSide.Left)
+      _ <- IO(assertEquals(lmPopResult, Some(("{listmove}:lmpop-b", List("1")))))
+      // lmPop: with an explicit count
+      _ <- redis.rPush("{listmove}:lmpop-c", "3", "4", "5")
+      lmPopCountResult <- redis.lmPop(NonEmptyList.one("{listmove}:lmpop-c"), LMoveSide.Left, 2)
+      _ <- IO(assertEquals(lmPopCountResult, Some(("{listmove}:lmpop-c", List("3", "4")))))
+      // lmPop: no key has elements
+      lmPopEmpty <- redis.lmPop(NonEmptyList.one("{listmove}:lmpop-empty"), LMoveSide.Left)
+      _ <- IO(assertEquals(lmPopEmpty, None))
+
+      // blmPop: element available immediately
+      _ <- redis.rPush("{listmove}:blmpop-a", "6")
+      blmPopResult <- redis.blmPop(1.second, NonEmptyList.one("{listmove}:blmpop-a"), LMoveSide.Left)
+      _ <- IO(assertEquals(blmPopResult, Some(("{listmove}:blmpop-a", List("6")))))
+      // blmPop: timeout expiry
+      blmPopTimeout <- redis.blmPop(1.second, NonEmptyList.one("{listmove}:blmpop-empty"), LMoveSide.Left)
+      _ <- IO(assertEquals(blmPopTimeout, None))
+
+      // lPos: basic position, and a missing element
+      _ <- redis.rPush("lpos-key", "a", "b", "c", "b")
+      lPosSingle <- redis.lPos("lpos-key", "b")
+      _ <- IO(assertEquals(lPosSingle, Some(1L)))
+      lPosMissing <- redis.lPos("lpos-key", "z")
+      _ <- IO(assertEquals(lPosMissing, None))
+      // lPos: RANK 2 skips to the second occurrence
+      lPosRank <- redis.lPos("lpos-key", "b", LPosArgs(rank = Some(2)))
+      _ <- IO(assertEquals(lPosRank, Some(3L)))
+      // lPos: COUNT 0 returns every occurrence
+      lPosCount <- redis.lPos("lpos-key", "b", 0L)
+      _ <- IO(assertEquals(lPosCount, List(1L, 3L)))
+      // lPos: COUNT 0 with MAXLEN limits how much of the list is scanned
+      lPosCountArgs <- redis.lPos("lpos-key", "b", 0L, LPosArgs(maxLen = Some(2)))
+      _ <- IO(assertEquals(lPosCountArgs, List(1L)))
+
+      // lPop/rPop multi-pop
+      _ <- redis.rPush("multipop-key", "1", "2", "3", "4")
+      lPopMulti <- redis.lPop("multipop-key", 2)
+      _ <- IO(assertEquals(lPopMulti, List("1", "2")))
+      rPopMulti <- redis.rPop("multipop-key", 2)
+      _ <- IO(assertEquals(rPopMulti, List("4", "3")))
     } yield ()
   }
 


### PR DESCRIPTION
## Summary

Part of closing the coverage gap between redis4cats and Lettuce 7.7.0.
Adds List command family coverage, consistent with the
`lMove`/`blMove`/`LMoveSide` design introduced in the prior Geo/List/Hash
3.0.0 redesign:

- **`lmPop`/`blmPop`** (LMPOP/BLMPOP) — pop from the first non-empty of
  several keys. Reuses `NonEmptyList[K]` (matching `blPop`/`brPop`'s
  existing shape) and `LMoveSide` for which end to pop from.
- **`lPos`** (LPOS) — find element position(s) in a list. New
  `LPosArgs(rank, maxLen)` case class following the `GeoStoreArgs`
  immutable-case-class-to-Java-builder pattern already established.
- **`lPop`/`rPop`** gained a `count`-taking overload for LPOP/RPOP's
  multi-pop form, alongside the existing single-element `Option`-returning
  ones.

**Not included: `lMoveMany`/`blMoveMany` (LMOVEM/BLMOVEM).** These were
in an earlier version of this PR but had to be dropped — while Lettuce
7.7.0's Java client exposes `lmovem`/`blmovem`, the actual Redis
`LMOVEM`/`BLMOVEM` commands only shipped in **Redis 8.10**
(redis/redis#15405), newer than the `redis:8.0.1` image this repo's CI
tests against (confirmed via CI failure: `ERR unknown command
'LMOVEM'`). This is a real version gap between what Lettuce's client
supports and what's testable/mergeable here today — tracked as a
follow-up once the CI Redis image is bumped (a separate, cross-cutting
decision, not scoped to this PR).

The remaining additions were each individually verified against Redis's
own command history to predate 8.0.1 safely: LMPOP/BLMPOP (Redis 7.0,
2021), LPOS (Redis 6.0.6), multi-arg LPOP/RPOP (Redis 6.2).

## Test plan

- [x] `sbt compile` + `Test/compile` across all modules — clean, zero warnings
- [x] `sbt mdoc` — clean
- [x] New coverage in `listsScenario` (`TestScenarios.scala`): `lmPop`/
  `blmPop` with and without an explicit count and with no available
  elements, all 4 `lPos` overloads (plain, `RANK`, `COUNT 0` for all
  occurrences, `COUNT 0` + `MAXLEN`), and multi-pop `lPop`/`rPop`
- [x] New multi-key test keys reuse the `{listmove}:` hash-tag prefix
  already established in this same scenario for `RedisClusterSpec`
  correctness; `lPos` and multi-pop `lPop`/`rPop` are single-key,
  correctly left untagged
- [x] CI: previously failed with `ERR unknown command 'LMOVEM'`; fixed
  by dropping that coverage, re-running now