### PR TITLE
series/3.x: close sorted sets command gap (ZMPOP/BZMPOP, ZRANGESTORE family, ZINTERCARD)

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/sortedsets.scala
@@ -58,10 +58,24 @@ trait SortedSetGetter[F[_], K, V] {
   def zPopMax(key: K, count: Long): F[List[ScoreWithValue[V]]]
   def bzPopMax(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
   def bzPopMin(timeout: Duration, keys: NonEmptyList[K]): F[Option[(K, ScoreWithValue[V])]]
+
+  /** Pops up to `count` members with the lowest scores from the first non-empty of `keys`. */
+  def zmPopMin(keys: NonEmptyList[K], count: Long): F[Option[(K, List[ScoreWithValue[V]])]]
+
+  /** Pops up to `count` members with the highest scores from the first non-empty of `keys`. */
+  def zmPopMax(keys: NonEmptyList[K], count: Long): F[Option[(K, List[ScoreWithValue[V]])]]
+  def bzmPopMin(timeout: Duration, keys: NonEmptyList[K], count: Long): F[Option[(K, List[ScoreWithValue[V]])]]
+  def bzmPopMax(timeout: Duration, keys: NonEmptyList[K], count: Long): F[Option[(K, List[ScoreWithValue[V]])]]
   def zUnion(args: Option[ZAggregateArgs], keys: K*): F[List[V]]
   def zUnionWithScores(args: Option[ZAggregateArgs], keys: K*): F[List[ScoreWithValue[V]]]
   def zInter(args: Option[ZAggregateArgs], keys: K*): F[List[V]]
   def zInterWithScores(args: Option[ZAggregateArgs], keys: K*): F[List[ScoreWithValue[V]]]
+
+  /** Cardinality of the intersection of `keys`, without materializing it. */
+  def zInterCard(keys: K*): F[Long]
+
+  /** As [[zInterCard]], but stops counting once `limit` is reached (0 means unlimited). */
+  def zInterCard(limit: Long, keys: K*): F[Long]
   def zDiff(keys: K*): F[List[V]]
   def zDiffWithScores(keys: K*): F[List[ScoreWithValue[V]]]
 }
@@ -76,4 +90,12 @@ trait SortedSetSetter[F[_], K, V] {
   def zRemRangeByRank(key: K, start: Long, stop: Long): F[Long]
   def zRemRangeByScore[T: Numeric](key: K, range: ZRange[T]): F[Long]
   def zUnionStore(destination: K, args: Option[ZStoreArgs], keys: K*): F[Long]
+
+  /** Stores the by-rank range `[start, stop]` of `key` into `destination`, returning the count stored. */
+  def zRangeStore(destination: K, key: K, start: Long, stop: Long): F[Long]
+  def zRangeStoreByScore[T: Numeric](destination: K, key: K, range: ZRange[T], limit: Option[RangeLimit]): F[Long]
+  def zRangeStoreByLex(destination: K, key: K, range: ZRange[V], limit: Option[RangeLimit]): F[Long]
+  def zRevRangeStore(destination: K, key: K, start: Long, stop: Long): F[Long]
+  def zRevRangeStoreByScore[T: Numeric](destination: K, key: K, range: ZRange[T], limit: Option[RangeLimit]): F[Long]
+  def zRevRangeStoreByLex(destination: K, key: K, range: ZRange[V], limit: Option[RangeLimit]): F[Long]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -1653,12 +1653,12 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def zmPopMin(keys: NonEmptyList[K], count: Long): F[Option[(K, List[ScoreWithValue[V]])]] =
     async
       .flatMap(_.zmpop(count.toInt, ZPopArgs.Builder.min(), keys.toList: _*).futureLift)
-      .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
+      .map(Option(_).filter(_.hasValue).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
 
   override def zmPopMax(keys: NonEmptyList[K], count: Long): F[Option[(K, List[ScoreWithValue[V]])]] =
     async
       .flatMap(_.zmpop(count.toInt, ZPopArgs.Builder.max(), keys.toList: _*).futureLift)
-      .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
+      .map(Option(_).filter(_.hasValue).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
 
   override def bzmPopMin(
       timeout: Duration,
@@ -1667,7 +1667,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   ): F[Option[(K, List[ScoreWithValue[V]])]] =
     async
       .flatMap(_.bzmpop(timeout.toSecondsOrZero, count, ZPopArgs.Builder.min(), keys.toList: _*).futureLift)
-      .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
+      .map(Option(_).filter(_.hasValue).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
 
   override def bzmPopMax(
       timeout: Duration,
@@ -1676,7 +1676,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   ): F[Option[(K, List[ScoreWithValue[V]])]] =
     async
       .flatMap(_.bzmpop(timeout.toSecondsOrZero, count, ZPopArgs.Builder.max(), keys.toList: _*).futureLift)
-      .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
+      .map(Option(_).filter(_.hasValue).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
 
   override def zUnion(args: Option[ZAggregateArgs], keys: K*): F[List[V]] = {
     val res = args match {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -67,6 +67,7 @@ import io.lettuce.core.{
   XTrimArgs => JXTrimArgs,
   ZAddArgs,
   ZAggregateArgs,
+  ZPopArgs,
   ZStoreArgs
 }
 import io.lettuce.core.models.stream.{ ClaimedMessages, PendingMessage, PendingMessages }
@@ -1439,6 +1440,70 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     res.map(x => Long.box(x))
   }
 
+  override def zRangeStore(destination: K, key: K, start: Long, stop: Long): F[Long] =
+    async
+      .flatMap(_.zrangestore(destination, key, JRange.create[java.lang.Long](start, stop)).futureLift)
+      .map(x => Long.box(x))
+
+  override def zRangeStoreByScore[T: Numeric](
+      destination: K,
+      key: K,
+      range: ZRange[T],
+      limit: Option[RangeLimit]
+  ): F[Long] = {
+    val res = limit match {
+      case Some(x) =>
+        async.flatMap(
+          _.zrangestorebyscore(destination, key, range.asJavaRange, JLimit.create(x.offset, x.count)).futureLift
+        )
+      case None =>
+        async.flatMap(_.zrangestorebyscore(destination, key, range.asJavaRange, JLimit.unlimited()).futureLift)
+    }
+    res.map(x => Long.box(x))
+  }
+
+  override def zRangeStoreByLex(destination: K, key: K, range: ZRange[V], limit: Option[RangeLimit]): F[Long] = {
+    val jRange = JRange.create[V](range.start, range.end)
+    val res = limit match {
+      case Some(x) =>
+        async.flatMap(_.zrangestorebylex(destination, key, jRange, JLimit.create(x.offset, x.count)).futureLift)
+      case None => async.flatMap(_.zrangestorebylex(destination, key, jRange, JLimit.unlimited()).futureLift)
+    }
+    res.map(x => Long.box(x))
+  }
+
+  override def zRevRangeStore(destination: K, key: K, start: Long, stop: Long): F[Long] =
+    async
+      .flatMap(_.zrevrangestore(destination, key, JRange.create[java.lang.Long](start, stop)).futureLift)
+      .map(x => Long.box(x))
+
+  override def zRevRangeStoreByScore[T: Numeric](
+      destination: K,
+      key: K,
+      range: ZRange[T],
+      limit: Option[RangeLimit]
+  ): F[Long] = {
+    val res = limit match {
+      case Some(x) =>
+        async.flatMap(
+          _.zrevrangestorebyscore(destination, key, range.asJavaRange, JLimit.create(x.offset, x.count)).futureLift
+        )
+      case None =>
+        async.flatMap(_.zrevrangestorebyscore(destination, key, range.asJavaRange, JLimit.unlimited()).futureLift)
+    }
+    res.map(x => Long.box(x))
+  }
+
+  override def zRevRangeStoreByLex(destination: K, key: K, range: ZRange[V], limit: Option[RangeLimit]): F[Long] = {
+    val jRange = JRange.create[V](range.start, range.end)
+    val res = limit match {
+      case Some(x) =>
+        async.flatMap(_.zrevrangestorebylex(destination, key, jRange, JLimit.create(x.offset, x.count)).futureLift)
+      case None => async.flatMap(_.zrevrangestorebylex(destination, key, jRange, JLimit.unlimited()).futureLift)
+    }
+    res.map(x => Long.box(x))
+  }
+
   override def zCard(key: K): F[Long] =
     async.flatMap(_.zcard(key).futureLift.map(x => Long.unbox(x)))
 
@@ -1585,6 +1650,34 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       .flatMap(_.bzpopmax(timeout.toSecondsOrZero, keys.toList: _*).futureLift)
       .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScoreWithValues)))
 
+  override def zmPopMin(keys: NonEmptyList[K], count: Long): F[Option[(K, List[ScoreWithValue[V]])]] =
+    async
+      .flatMap(_.zmpop(count.toInt, ZPopArgs.Builder.min(), keys.toList: _*).futureLift)
+      .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
+
+  override def zmPopMax(keys: NonEmptyList[K], count: Long): F[Option[(K, List[ScoreWithValue[V]])]] =
+    async
+      .flatMap(_.zmpop(count.toInt, ZPopArgs.Builder.max(), keys.toList: _*).futureLift)
+      .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
+
+  override def bzmPopMin(
+      timeout: Duration,
+      keys: NonEmptyList[K],
+      count: Long
+  ): F[Option[(K, List[ScoreWithValue[V]])]] =
+    async
+      .flatMap(_.bzmpop(timeout.toSecondsOrZero, count, ZPopArgs.Builder.min(), keys.toList: _*).futureLift)
+      .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
+
+  override def bzmPopMax(
+      timeout: Duration,
+      keys: NonEmptyList[K],
+      count: Long
+  ): F[Option[(K, List[ScoreWithValue[V]])]] =
+    async
+      .flatMap(_.bzmpop(timeout.toSecondsOrZero, count, ZPopArgs.Builder.max(), keys.toList: _*).futureLift)
+      .map(Option(_).map(kv => (kv.getKey, kv.getValue.asScala.toList.map(_.asScoreWithValues))))
+
   override def zUnion(args: Option[ZAggregateArgs], keys: K*): F[List[V]] = {
     val res = args match {
       case Some(aggArgs) => async.flatMap(_.zunion(aggArgs, keys: _*).futureLift)
@@ -1616,6 +1709,12 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     }
     res.map(_.asScala.toList.map(_.asScoreWithValues))
   }
+
+  override def zInterCard(keys: K*): F[Long] =
+    async.flatMap(_.zintercard(keys: _*).futureLift.map(x => Long.box(x)))
+
+  override def zInterCard(limit: Long, keys: K*): F[Long] =
+    async.flatMap(_.zintercard(limit, keys: _*).futureLift.map(x => Long.box(x)))
 
   override def zDiff(keys: K*): F[List[V]] =
     async.flatMap(_.zdiff(keys: _*).futureLift.map(_.asScala.toList))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -500,6 +500,56 @@ trait TestScenarios { self: FunSuite =>
                  randomValuesWithScore.distinct.size == 2
              )
            )
+
+      // zmPopMin/zmPopMax: pop from the first non-empty of several keys
+      _ <- redis.del(testKey, otherTestKey)
+      zmPopEmpty <- redis.zmPopMin(NonEmptyList.of(testKey, otherTestKey), 1)
+      _ <- IO(assert(zmPopEmpty.isEmpty))
+      _ <- redis.zAdd(otherTestKey, args = None, scoreWithValue1, scoreWithValue2, scoreWithValue3)
+      zmPopMinResult <- redis.zmPopMin(NonEmptyList.of(testKey, otherTestKey), 2)
+      _ <- IO(assertEquals(zmPopMinResult, Some((otherTestKey, List(scoreWithValue1, scoreWithValue2)))))
+      zmPopMaxResult <- redis.zmPopMax(NonEmptyList.of(testKey, otherTestKey), 1)
+      _ <- IO(assertEquals(zmPopMaxResult, Some((otherTestKey, List(scoreWithValue3)))))
+      _ <- redis.zAdd(otherTestKey, args = None, scoreWithValue1)
+      bzmPopMinResult <- redis.bzmPopMin(timeout, NonEmptyList.of(testKey, otherTestKey), 1)
+      _ <- IO(assertEquals(bzmPopMinResult, Some((otherTestKey, List(scoreWithValue1)))))
+      bzmPopEmptyResult <- redis.bzmPopMax(timeout, NonEmptyList.one(testKey), 1)
+      _ <- IO(assert(bzmPopEmptyResult.isEmpty))
+
+      // zInterCard: cardinality of intersection without materializing it
+      _ <- redis.zAdd(testKey, args = None, scoreWithValue1, scoreWithValue2)
+      _ <- redis.zAdd(otherTestKey, args = None, scoreWithValue1, scoreWithValue3)
+      interCard <- redis.zInterCard(testKey, otherTestKey)
+      _ <- IO(assertEquals(interCard, 1L))
+      interCardLimited <- redis.zInterCard(0, testKey, otherTestKey)
+      _ <- IO(assertEquals(interCardLimited, 1L))
+
+      // zRangeStore/zRevRangeStore: by-rank range into a destination key
+      rangeStoreCount <- redis.zRangeStore("{same_hash_slot}:range-store-dest", testKey, 0, -1)
+      _ <- IO(assertEquals(rangeStoreCount, 2L))
+      rangeStoreMembers <- redis.zRangeWithScores("{same_hash_slot}:range-store-dest", 0, -1)
+      _ <- IO(assertEquals(rangeStoreMembers, List(scoreWithValue1, scoreWithValue2)))
+      revRangeStoreCount <- redis.zRevRangeStore("{same_hash_slot}:rev-range-store-dest", testKey, 0, -1)
+      _ <- IO(assertEquals(revRangeStoreCount, 2L))
+      revRangeStoreMembers <- redis.zRangeWithScores("{same_hash_slot}:rev-range-store-dest", 0, -1)
+      _ <- IO(assertEquals(revRangeStoreMembers, List(scoreWithValue1, scoreWithValue2)))
+
+      // zRangeStoreByScore/zRevRangeStoreByScore
+      rangeStoreByScoreCount <-
+        redis.zRangeStoreByScore("{same_hash_slot}:range-store-score-dest", testKey, ZRange(0, 1), limit = None)
+      _ <- IO(assertEquals(rangeStoreByScoreCount, 1L))
+      rangeStoreByScoreMembers <- redis.zRangeWithScores("{same_hash_slot}:range-store-score-dest", 0, -1)
+      _ <- IO(assertEquals(rangeStoreByScoreMembers, List(scoreWithValue1)))
+      revRangeStoreByScoreCount <-
+        redis.zRevRangeStoreByScore(
+          "{same_hash_slot}:rev-range-store-score-dest",
+          testKey,
+          ZRange(0, 3),
+          limit = Some(RangeLimit(0, 1))
+        )
+      _ <- IO(assertEquals(revRangeStoreByScoreCount, 1L))
+      revRangeStoreByScoreMembers <- redis.zRangeWithScores("{same_hash_slot}:rev-range-store-score-dest", 0, -1)
+      _ <- IO(assertEquals(revRangeStoreByScoreMembers, List(scoreWithValue2)))
     } yield ()
   }
 


### PR DESCRIPTION
## Summary

Part of closing the command-coverage gap between redis4cats and what
Lettuce 7.7.0 actually exposes for sorted sets. Adds:

- `zmPopMin`/`zmPopMax`/`bzmPopMin`/`bzmPopMax` — pop from the first
  non-empty of several sorted-set keys (`ZMPOP`/`BZMPOP`), analogous to
  the list-side `LMPOP`/`BLMPOP` this library already has. Returns
  `Option[(K, List[ScoreWithValue[V]])]`, mirroring the existing
  `bzPopMin`/`bzPopMax` shape (`Option[(K, ScoreWithValue[V])]`) one
  level up to account for the count.
- `zRangeStore`/`zRevRangeStore` (by-rank) plus `zRangeStoreByScore`/
  `zRevRangeStoreByScore`/`zRangeStoreByLex`/`zRevRangeStoreByLex` —
  the full `ZRANGESTORE`/`ZREVRANGESTORE` family, previously entirely
  absent. Reuses the existing `ZRange[T]`/`RangeLimit` abstractions
  already used by `zRangeByScore`/`zRangeByLex` rather than inventing a
  new range type.
- `zInterCard(keys*)` / `zInterCard(limit, keys*)` — intersection
  cardinality without materializing the result set, analogous to the
  already-added `sInterCard`/`sUnionStore`-family pattern on the sets side.

All new `F[Long]`-returning methods propagate the real Redis-computed
count, consistent with the "never discard information" policy from the
prior Geo/List/Hash redesign (#1180).

## Test plan

- [x] `sbt compile` + `Test/compile` across all modules — clean, zero warnings
- [x] `sbt mdoc` — clean
- [x] New test coverage in `TestScenarios.scala`'s `sortedSetsScenario`: `zmPopMin`/`zmPopMax` popping the correct member(s) from the correct key, empty-keys case, `bzmPopMin`/`bzmPopMax` blocking variants (both a hit and a timeout-to-empty case), `zInterCard` with and without a limit, `zRangeStore`/`zRevRangeStore` by-rank plus `zRangeStoreByScore`/`zRevRangeStoreByScore` verified by reading back the stored destination key's contents
- [ ] `zRangeStoreByLex`/`zRevRangeStoreByLex` are implemented but not exercised in the test scenario — it uses `Long`-valued sorted sets, where lexicographic ranges aren't semantically meaningful (matching this scenario's existing precedent of not testing `zRangeByLex`/`zRevRangeByLex` either)
- [ ] CI integration tests against real Redis (single-node and cluster) — can't run locally in this environment; new multi-key test keys reuse the scenario's existing `{same_hash_slot}:` hash-tag prefix for cluster-safety