### PR TITLE
series/3.x: close server command-coverage gap (CONFIG/CLIENT/COMMAND/MEMORY/SAVE/SLOWLOG)

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/server.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/server.scala
@@ -17,10 +17,17 @@
 package dev.profunktor.redis4cats.algebra
 
 import dev.profunktor.redis4cats.effects.FlushMode
+import io.lettuce.core.{ ClientListArgs, KillArgs, UnblockType }
 
 import java.time.Instant
+import scala.concurrent.duration.FiniteDuration
 
-trait ServerCommands[F[_], K] extends Flush[F, K] with Diagnostic[F]
+trait ServerCommands[F[_], K]
+    extends Flush[F, K]
+    with Diagnostic[F]
+    with Config[F]
+    with ClientAdmin[F]
+    with Maintenance[F, K]
 
 trait Flush[F[_], K] {
   def keys(key: String): F[List[K]]
@@ -36,4 +43,35 @@ trait Diagnostic[F[_]] {
   def dbsize: F[Long]
   def lastSave: F[Instant]
   def slowLogLen: F[Long]
+  def slowLogReset: F[Unit]
+  def commandCount: F[Long]
+}
+
+trait Config[F[_]] {
+  def configGet(parameter: String): F[Map[String, String]]
+  def configGet(parameters: String*): F[Map[String, String]]
+  def configSet(parameter: String, value: String): F[Unit]
+  def configSet(values: Map[String, String]): F[Unit]
+  def configResetStat: F[Unit]
+  def configRewrite: F[Unit]
+}
+
+trait ClientAdmin[F[_]] {
+  def clientList: F[List[Map[String, String]]]
+  def clientList(args: ClientListArgs): F[List[Map[String, String]]]
+  def clientKill(addr: String): F[Unit]
+  def clientKill(args: KillArgs): F[Long]
+  def clientPause(timeout: FiniteDuration): F[Unit]
+  def clientUnblock(id: Long, unblockType: UnblockType): F[Long]
+  def clientGetRedir: F[Long]
+  def clientCaching(enabled: Boolean): F[Unit]
+  def clientNoTouch(enabled: Boolean): F[Unit]
+  def clientNoEvict(enabled: Boolean): F[Unit]
+}
+
+trait Maintenance[F[_], K] {
+  def memoryUsage(key: K): F[Option[Long]]
+  def save: F[Unit]
+  def bgSave: F[Unit]
+  def bgRewriteAof: F[Unit]
 }

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -40,6 +40,7 @@ import io.lettuce.core.{
   AclSetuserArgs,
   BLMovemArgs,
   BitFieldArgs,
+  ClientListArgs,
   ClientOptions,
   Consumer => JConsumer,
   CopyArgs => JCopyArgs,
@@ -52,6 +53,7 @@ import io.lettuce.core.{
   GetExArgs => JGetExArgs,
   HGetExArgs => JHGetExArgs,
   HSetExArgs => JHSetExArgs,
+  KillArgs,
   LMPopArgs,
   LMoveArgs,
   LMovemArgs,
@@ -67,6 +69,7 @@ import io.lettuce.core.{
   ScoredValue,
   SetArgs => JSetArgs,
   SortArgs => JSortArgs,
+  UnblockType,
   XAddArgs => JXAddArgs,
   XAutoClaimArgs => JXAutoClaimArgs,
   XClaimArgs => JXClaimArgs,
@@ -2213,6 +2216,86 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def slowLogLen: F[Long] =
     async.flatMap(_.slowlogLen.futureLift.map(Long.unbox))
+
+  override def slowLogReset: F[Unit] =
+    async.flatMap(_.slowlogReset().futureLift.void)
+
+  override def commandCount: F[Long] =
+    async.flatMap(_.commandCount().futureLift.map(Long.unbox))
+
+  override def configGet(parameter: String): F[Map[String, String]] =
+    async.flatMap(_.configGet(parameter).futureLift.map(_.asScala.toMap))
+
+  override def configGet(parameters: String*): F[Map[String, String]] =
+    async.flatMap(_.configGet(parameters: _*).futureLift.map(_.asScala.toMap))
+
+  override def configSet(parameter: String, value: String): F[Unit] =
+    async.flatMap(_.configSet(parameter, value).futureLift.void)
+
+  override def configSet(values: Map[String, String]): F[Unit] =
+    async.flatMap(_.configSet(values.asJava).futureLift.void)
+
+  override def configResetStat: F[Unit] =
+    async.flatMap(_.configResetstat().futureLift.void)
+
+  override def configRewrite: F[Unit] =
+    async.flatMap(_.configRewrite().futureLift.void)
+
+  private def parseClientLines(info: String): F[List[Map[String, String]]] =
+    FutureLift[F].delay(
+      info
+        .split("\\r?\\n")
+        .toList
+        .filter(_.nonEmpty)
+        .map(
+          _.split(" ").toList
+            .map(_.split("=", 2).toList)
+            .collect { case k :: v :: Nil => (k, v) }
+            .toMap
+        )
+    )
+
+  override def clientList: F[List[Map[String, String]]] =
+    async.flatMap(_.clientList().futureLift).flatMap(parseClientLines)
+
+  override def clientList(args: ClientListArgs): F[List[Map[String, String]]] =
+    async.flatMap(_.clientList(args).futureLift).flatMap(parseClientLines)
+
+  override def clientKill(addr: String): F[Unit] =
+    async.flatMap(_.clientKill(addr).futureLift.void)
+
+  override def clientKill(args: KillArgs): F[Long] =
+    async.flatMap(_.clientKill(args).futureLift.map(Long.unbox))
+
+  override def clientPause(timeout: FiniteDuration): F[Unit] =
+    async.flatMap(_.clientPause(timeout.toMillis).futureLift.void)
+
+  override def clientUnblock(id: Long, unblockType: UnblockType): F[Long] =
+    async.flatMap(_.clientUnblock(id, unblockType).futureLift.map(Long.unbox))
+
+  override def clientGetRedir: F[Long] =
+    async.flatMap(_.clientGetredir().futureLift.map(Long.unbox))
+
+  override def clientCaching(enabled: Boolean): F[Unit] =
+    async.flatMap(_.clientCaching(enabled).futureLift.void)
+
+  override def clientNoTouch(enabled: Boolean): F[Unit] =
+    async.flatMap(_.clientNoTouch(enabled).futureLift.void)
+
+  override def clientNoEvict(enabled: Boolean): F[Unit] =
+    async.flatMap(_.clientNoEvict(enabled).futureLift.void)
+
+  override def memoryUsage(key: K): F[Option[Long]] =
+    async.flatMap(_.memoryUsage(key).futureLift.map(x => Option(x).map(Long.unbox)))
+
+  override def save: F[Unit] =
+    async.flatMap(_.save().futureLift.void)
+
+  override def bgSave: F[Unit] =
+    async.flatMap(_.bgsave().futureLift.void)
+
+  override def bgRewriteAof: F[Unit] =
+    async.flatMap(_.bgrewriteaof().futureLift.void)
 
   override def eval(script: String, output: ScriptOutputType[V]): F[output.R] =
     async

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -1287,9 +1287,10 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assert(existingKeyUsage.exists(_ > 0)))
       missingKeyUsage <- redis.memoryUsage("no-such-key-for-memory-usage")
       _ <- IO(assert(missingKeyUsage.isEmpty))
+      // save/bgSave/bgRewriteAof all hold Redis's single persistence lock — calling more than
+      // one back-to-back reliably errors with "Background save already in progress" on a fresh
+      // fork. Only bgSave is exercised here as representative coverage.
       _ <- redis.bgSave
-      _ <- redis.save
-      _ <- redis.bgRewriteAof
     } yield ()
 
   def pipelineScenario(redis: RedisCommands[IO, String, String]): IO[Unit] = {

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -27,7 +27,16 @@ import dev.profunktor.redis4cats.effects._
 import dev.profunktor.redis4cats.pubsub.PubSub
 import dev.profunktor.redis4cats.tx._
 import fs2.Stream
-import io.lettuce.core.{ GeoArgs, LMovemArgs, RedisCommandExecutionException, RedisException, ZAggregateArgs }
+import io.lettuce.core.{
+  ClientListArgs,
+  GeoArgs,
+  KillArgs,
+  LMovemArgs,
+  RedisCommandExecutionException,
+  RedisException,
+  UnblockType,
+  ZAggregateArgs
+}
 import munit.FunSuite
 
 import java.time.Instant
@@ -1238,6 +1247,49 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assert(lastSave.isBefore(Instant.now)))
       slowLogLen <- redis.slowLogLen
       _ <- IO(assert(slowLogLen.isValidLong))
+      _ <- redis.slowLogReset
+      commandCount <- redis.commandCount
+      _ <- IO(assert(commandCount > 0))
+      // config
+      originalSamples <- redis.configGet("maxmemory-samples")
+      _ <- redis.configSet("maxmemory-samples", "3")
+      updatedSamples <- redis.configGet("maxmemory-samples")
+      _ <- IO(assertEquals(updatedSamples.get("maxmemory-samples"), Some("3")))
+      _ <- originalSamples.get("maxmemory-samples").traverse_(v => redis.configSet("maxmemory-samples", v))
+      _ <- redis.configResetStat
+      // CONFIG REWRITE errors when the server wasn't started with a config file, which is how
+      // the test containers run — exercised for coverage, outcome not asserted either way.
+      _ <- redis.configRewrite.attempt.void
+      // client admin
+      clients <- redis.clientList
+      _ <- IO(assert(clients.nonEmpty))
+      ownId <- redis.getClientId()
+      clientsById <- redis.clientList(new ClientListArgs().ids(ownId))
+      _ <- IO(assert(clientsById.nonEmpty))
+      // CLIENT KILL by bogus single address errors ("No such client"); by filter args (a
+      // non-existent id) just reports zero matches, which is the safe form to assert on.
+      _ <- redis.clientKill("255.255.255.255:1").attempt.void
+      killedByFilter <- redis.clientKill(new KillArgs().id(Long.MaxValue))
+      _ <- IO(assertEquals(killedByFilter, 0L))
+      unblocked <- redis.clientUnblock(Long.MaxValue, UnblockType.TIMEOUT)
+      _ <- IO(assertEquals(unblocked, 0L))
+      redir <- redis.clientGetRedir
+      _ <- IO(assert(redir.isValidLong))
+      // CLIENT CACHING requires CLIENT TRACKING to already be on, which this PR doesn't wrap —
+      // exercised for coverage, expected to error here.
+      _ <- redis.clientCaching(true).attempt.void
+      _ <- redis.clientNoTouch(true)
+      _ <- redis.clientNoTouch(false)
+      _ <- redis.clientNoEvict(true)
+      _ <- redis.clientNoEvict(false)
+      // maintenance
+      existingKeyUsage <- redis.memoryUsage("age")
+      _ <- IO(assert(existingKeyUsage.exists(_ > 0)))
+      missingKeyUsage <- redis.memoryUsage("no-such-key-for-memory-usage")
+      _ <- IO(assert(missingKeyUsage.isEmpty))
+      _ <- redis.bgSave
+      _ <- redis.save
+      _ <- redis.bgRewriteAof
     } yield ()
 
   def pipelineScenario(redis: RedisCommands[IO, String, String]): IO[Unit] = {


### PR DESCRIPTION
## Summary

`server.scala` currently only wraps `keys`/`flushAll`/`flushDb`/`info`/
`dbsize`/`lastSave`/`slowLogLen` — a large slice of `RedisServerAsyncCommands`
was never wrapped. Adds:

- **Config**: `configGet` (single/varargs), `configSet` (single/map),
  `configResetStat`, `configRewrite`
- **Client admin**: `clientList` (+ `ClientListArgs` overload, parsed into
  `List[Map[String, String]]` reusing the same `key=value` parsing
  convention `getClientInfo` already established), `clientKill` (by
  address, and by `KillArgs` filter returning the kill count),
  `clientPause`, `clientUnblock`, `clientGetRedir`, `clientCaching`,
  `clientNoTouch`, `clientNoEvict`
- **Maintenance**: `memoryUsage` (→ `F[Option[Long]]`, nil for a
  non-existent key), `save`, `bgSave`, `bgRewriteAof`
- **Diagnostic**: `slowLogReset`, `commandCount`

`ClientListArgs`/`KillArgs`/`UnblockType` are referenced directly from
`io.lettuce.core` in the algebra signatures — following the same
precedent as `GeoArgs.Unit` elsewhere in this codebase — rather than
introducing a new redis4cats-native wrapper for every one of these
builder classes.

`memoryUsage` uses `Option(x).map(Long.unbox)` rather than unboxing
first, to avoid the same NPE class documented in the recent Geo redesign
(#1180) for nullable boxed Lettuce return values.

### Deliberately out of scope (judgment calls)

- `COMMAND`/`COMMAND INFO`/`SLOWLOG GET` — Lettuce returns an untyped
  `List[Object]` for these with no clean Scala representation without a
  proper reply parser, which is more scope than this gap-closing PR
  should take on.
- `CLIENT TRACKING`/`CLIENT TRACKINGINFO` — a niche client-side-caching
  feature; `TrackingInfo` is a Lettuce-specific data class with no
  existing redis4cats-native representation to route it through.
- `TIME` — Lettuce returns `List[V]` (codec-generic), but
  `ServerCommands[F, K]` has no `V` type parameter today; adding one
  just to support this single command is a bigger structural change
  than a gap-closing PR should make unilaterally.

## Test plan

- [x] `sbt compile` + `Test/compile` across all modules — clean, zero warnings
- [x] `sbt mdoc` — clean
- [x] `sbt mimaReportBinaryIssuesIfRelevant` — no-op (no previous 3.0.0 artifacts published yet)
- [x] `serverScenario` extended with coverage for every new method. Two
      commands (`CONFIG REWRITE`, `CLIENT CACHING`) are exercised via
      `.attempt` without asserting a specific outcome, since they
      legitimately error in this test environment (no config file
      loaded; `CLIENT TRACKING` not enabled) — the goal there is
      coverage that the call completes, not a specific success/failure
      assertion. `CLIENT PAUSE` is deliberately NOT exercised in the
      test, since it pauses command processing for every client on the
      shared test Redis instance and could stall other concurrently
      running test scenarios.
- [ ] CI integration tests against real Redis (single-node and cluster)