### PR TITLE
series/3.x: bump SingleNode/ReplicaNode test image to redis:8.10.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   SingleNode:
     restart: always
-    image: redis:8.0.1
+    image: redis:8.10.1
     ports:
       - "6379:6379"
     environment:
@@ -10,7 +10,7 @@ services:
 
   ReplicaNode:
     restart: always
-    image: redis:8.0.1
+    image: redis:8.10.1
     ports:
       - "6380:6379"
     command: redis-server --replicaof SingleNode 6379


### PR DESCRIPTION
Lettuce 7.7.0 adds support for several commands introduced in Redis 8.10 (SUNIONCARD, SDIFFCARD, LMOVEM/BLMOVEM among them). Our CI was pinned to redis:8.0.1, so those commands genuinely didn't exist on the server — PRs #1183 and #1185 had to drop coverage for them after hitting `ERR unknown command` in CI.

This bumps `SingleNode`/`ReplicaNode` to `redis:8.10.1` (verified locally: `INFO server` reports 8.10.1, and `SUNIONCARD` now returns a real result instead of erroring).

`RedisCluster` intentionally stays on the custom `yisraelu/redis-cluster:8.0.1` image — that's hand-maintained separately by the repo owner and will be bumped independently.

Follow-up once this merges: restore `sUnionCard`/`sDiffCard` (dropped from #1183) for single-node coverage, and re-check `LMOVEM`/`BLMOVEM` (dropped from #1185).