### PR TITLE
series/3.x: ignore local deferred-work tracking file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ tq:q
 .bsp
 .envrc
 docs/superpowers/
+docs/deferred-work.md


### PR DESCRIPTION
Small housekeeping change: ignores `docs/deferred-work.md`, a local-only backlog file tracking everything skipped/dropped/deferred across the #1180-#1190 command-coverage effort, for later review. Mirrors the existing `docs/superpowers/` entry — never meant to be committed.