### PR TITLE
series/3.x: close strings/bitmaps command gap (LCS, new BITOP variants, INCREX, MSETEX)

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/bitmaps.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/bitmaps.scala
@@ -55,6 +55,18 @@ trait BitCommands[F[_], K, V] {
 
   def bitOpXor(destination: K, source: K, sources: K*): F[Long]
 
+  /** X ∧ ¬(Y1 ∨ Y2 ∨ …) — bits set in `source` but in none of `keys`. */
+  def bitOpDiff(destination: K, source: K, keys: K*): F[Long]
+
+  /** ¬X ∧ (Y1 ∨ Y2 ∨ …) — bits set in at least one of `keys` but not in `source`. */
+  def bitOpDiff1(destination: K, source: K, keys: K*): F[Long]
+
+  /** X ∧ (Y1 ∨ Y2 ∨ …) — bits set in `source` and in at least one of `keys`. */
+  def bitOpAndOr(destination: K, source: K, keys: K*): F[Long]
+
+  /** Bits set in exactly one of `keys` (a generalized XOR — for two keys it's equivalent to `bitOpXor`). */
+  def bitOpOne(destination: K, keys: K*): F[Long]
+
   def bitPos(key: K, state: Boolean): F[Long]
 
   def bitPos(key: K, state: Boolean, start: Long): F[Long]

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/strings.scala
@@ -18,7 +18,15 @@ package dev.profunktor.redis4cats.algebra
 
 import scala.concurrent.duration.FiniteDuration
 
-import dev.profunktor.redis4cats.effects.{ GetExArg, SetArgs }
+import dev.profunktor.redis4cats.effects.{
+  GetExArg,
+  IncrexArgs,
+  IncrexFloatArgs,
+  IncrexResult,
+  LcsResult,
+  MSetExArgs,
+  SetArgs
+}
 
 import io.lettuce.core.RedisFuture
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands
@@ -37,6 +45,16 @@ trait Getter[F[_], K, V] {
   def getEx(key: K, getExArg: GetExArg): F[Option[V]]
   def getRange(key: K, start: Long, end: Long): F[Option[V]]
   def strLen(key: K): F[Long]
+
+  /** Longest common subsequence of the values stored at `key1`/`key2`, without match positions. */
+  def lcs(key1: K, key2: K): F[LcsResult]
+
+  /** Just the length of the longest common subsequence — cheaper than `lcs` when the match itself isn't needed.
+    */
+  def lcsLen(key1: K, key2: K): F[Long]
+
+  /** Longest common subsequence with match positions in each key's value populated. */
+  def lcsIdx(key1: K, key2: K, minMatchLen: Option[Int] = None, withMatchLen: Boolean = false): F[LcsResult]
 }
 
 trait Setter[F[_], K, V] {
@@ -53,6 +71,11 @@ trait MultiKey[F[_], K, V] {
   def mGet(keys: Set[K]): F[Map[K, V]]
   def mSet(keyValues: Map[K, V]): F[Unit]
   def mSetNx(keyValues: Map[K, V]): F[Boolean]
+
+  /** Atomic multi-key SET with a shared TTL/existence policy — `false` iff `args.existence` was `Nx`/`Xx` and that
+    * condition wasn't met, in which case no key was written.
+    */
+  def msetEx(keyValues: Map[K, V], args: MSetExArgs): F[Boolean]
 }
 
 trait Decrement[F[_], K, V] {
@@ -64,6 +87,15 @@ trait Increment[F[_], K, V] {
   def incr(key: K): F[Long]
   def incrBy(key: K, amount: Long): F[Long]
   def incrByFloat(key: K, amount: Double): F[Double]
+
+  /** Atomically increment by 1 with no bound/TTL change — the plain read-modify form of INCREX. */
+  def incrEx(key: K): F[IncrexResult[Long]]
+
+  /** Atomically increment (optionally bounded/saturating) and set/clear the key's TTL in one round trip. */
+  def incrEx(key: K, amount: Long, args: IncrexArgs): F[IncrexResult[Long]]
+
+  /** Float-valued counterpart of the bounded `incrEx` overload. */
+  def incrExFloat(key: K, amount: Double, args: IncrexFloatArgs): F[IncrexResult[Double]]
 }
 
 trait Unsafe[F[_], K, V] {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -577,6 +577,84 @@ object effects {
     def apply(ex: HSetExArg.Existence, ttl: HSetExArg.Ttl): HSetExArgs = HSetExArgs(Some(ex), Some(ttl))
   }
 
+  sealed trait MSetExTtl
+  object MSetExTtl {
+
+    /** Set expiration relative, in seconds */
+    case class Ex(duration: FiniteDuration) extends MSetExTtl
+
+    /** Set expiration relative, in millis */
+    case class Px(duration: FiniteDuration) extends MSetExTtl
+
+    /** Set expiration at an absolute time, second precision */
+    case class ExAt(at: Instant) extends MSetExTtl
+
+    /** Set expiration at an absolute time, millisecond precision */
+    case class PxAt(at: Instant) extends MSetExTtl
+
+    /** Retain the TTL already set on any keys being overwritten */
+    case object KeepTtl extends MSetExTtl
+  }
+
+  /** Args for `msetEx`: an atomic multi-key SET with a shared TTL/existence policy across every key. */
+  case class MSetExArgs(ttl: Option[MSetExTtl] = None, existence: Option[SetArg.Existence] = None)
+
+  /** A single match found by `lcsIdx`: matching character ranges in each of the two compared keys. `matchLen` is
+    * present only when the query asked for it.
+    */
+  case class LcsMatchPosition(start: Long, end: Long)
+  case class LcsMatch(a: LcsMatchPosition, b: LcsMatchPosition, matchLen: Option[Long])
+
+  /** Result of `lcs`/`lcsIdx`: `matchString` is present for the plain (non-idx) query, `matches` is populated only by
+    * `lcsIdx`, and `len` (the LCS length) is always present.
+    */
+  case class LcsResult(matchString: Option[String], matches: List[LcsMatch], len: Long)
+
+  sealed trait IncrexTtl
+  object IncrexTtl {
+
+    /** Set expiration relative, in seconds */
+    case class Ex(duration: FiniteDuration) extends IncrexTtl
+
+    /** Set expiration relative, in millis */
+    case class Px(duration: FiniteDuration) extends IncrexTtl
+
+    /** Set expiration at an absolute time, second precision */
+    case class ExAt(at: Instant) extends IncrexTtl
+
+    /** Set expiration at an absolute time, millisecond precision */
+    case class PxAt(at: Instant) extends IncrexTtl
+
+    /** Clear any existing expiration on the key */
+    case object Persist extends IncrexTtl
+  }
+
+  /** Args for `incrEx`: bounds are clamped-to (rather than rejecting the operation) when `saturate` is set — without
+    * it, an out-of-bounds increment is a no-op that leaves the key and its TTL unchanged. `ttlOnlyIfNoneSet` maps to
+    * Redis's ENX flag: apply `ttl` only if the key doesn't already have one.
+    */
+  case class IncrexArgs(
+      lowerBound: Option[Long] = None,
+      upperBound: Option[Long] = None,
+      saturate: Boolean = false,
+      ttl: Option[IncrexTtl] = None,
+      ttlOnlyIfNoneSet: Boolean = false
+  )
+
+  /** Float-bounded counterpart of `IncrexArgs`, for `incrExFloat`. */
+  case class IncrexFloatArgs(
+      lowerBound: Option[Double] = None,
+      upperBound: Option[Double] = None,
+      saturate: Boolean = false,
+      ttl: Option[IncrexTtl] = None,
+      ttlOnlyIfNoneSet: Boolean = false
+  )
+
+  /** Result of `incrEx`/`incrExFloat`: the key's new value, and the increment Redis actually applied (differs from the
+    * requested increment only when `saturate` clamped the result to a bound).
+    */
+  case class IncrexResult[A](value: A, appliedIncrement: A)
+
   sealed trait LMoveSide
   object LMoveSide {
     case object Left extends LMoveSide

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -54,12 +54,16 @@ import io.lettuce.core.{
   GetExArgs => JGetExArgs,
   HGetExArgs => JHGetExArgs,
   HSetExArgs => JHSetExArgs,
+  IncrexArgs => JIncrexArgs,
+  IncrexFloatArgs => JIncrexFloatArgs,
   KillArgs => JKillArgs,
   LMPopArgs,
   LMoveArgs,
   LMovemArgs,
   LPosArgs => JLPosArgs,
+  LcsArgs => JLcsArgs,
   Limit => JLimit,
+  MSetExArgs => JMSetExArgs,
   MigrateArgs => JMigrateArgs,
   Range => JRange,
   ReadFrom => JReadFrom,
@@ -71,6 +75,7 @@ import io.lettuce.core.{
   ScoredValue,
   SetArgs => JSetArgs,
   SortArgs => JSortArgs,
+  StringMatchResult => JStringMatchResult,
   TrackingArgs => JTrackingArgs,
   TrackingInfo => JTrackingInfo,
   UnblockType => JUnblockType,
@@ -848,6 +853,56 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def incrByFloat(key: K, amount: Double): F[Double] =
     async.flatMap(_.incrbyfloat(key, amount).futureLift.map(x => Double.box(x)))
 
+  // ex/px/exAt/pxAt on IncrexArgs/IncrexFloatArgs take raw longs (seconds/millis/epoch), unlike
+  // GetExArgs/HGetExArgs's Instant-accepting exAt/pxAt — a genuine difference in Lettuce's own API
+  // shape between the two command families, not an inconsistency on our side.
+  private def toJIncrexArgs(args: IncrexArgs): JIncrexArgs = {
+    val jArgs = new JIncrexArgs()
+    args.lowerBound.foreach(jArgs.lbound)
+    args.upperBound.foreach(jArgs.ubound)
+    if (args.saturate) jArgs.saturate(): Unit
+    args.ttl.foreach {
+      case IncrexTtl.Ex(d)    => jArgs.ex(d.toSeconds)
+      case IncrexTtl.Px(d)    => jArgs.px(d.toMillis)
+      case IncrexTtl.ExAt(at) => jArgs.exAt(at.getEpochSecond)
+      case IncrexTtl.PxAt(at) => jArgs.pxAt(at.toEpochMilli)
+      case IncrexTtl.Persist  => jArgs.persist()
+    }
+    if (args.ttlOnlyIfNoneSet) jArgs.enx(): Unit
+    jArgs
+  }
+
+  private def toJIncrexFloatArgs(args: IncrexFloatArgs): JIncrexFloatArgs = {
+    val jArgs = new JIncrexFloatArgs()
+    args.lowerBound.foreach(jArgs.lbound)
+    args.upperBound.foreach(jArgs.ubound)
+    if (args.saturate) jArgs.saturate(): Unit
+    args.ttl.foreach {
+      case IncrexTtl.Ex(d)    => jArgs.ex(d.toSeconds)
+      case IncrexTtl.Px(d)    => jArgs.px(d.toMillis)
+      case IncrexTtl.ExAt(at) => jArgs.exAt(at.getEpochSecond)
+      case IncrexTtl.PxAt(at) => jArgs.pxAt(at.toEpochMilli)
+      case IncrexTtl.Persist  => jArgs.persist()
+    }
+    if (args.ttlOnlyIfNoneSet) jArgs.enx(): Unit
+    jArgs
+  }
+
+  override def incrEx(key: K): F[IncrexResult[Long]] =
+    async.flatMap(_.increx(key).futureLift.map(v => IncrexResult(v.getValue.longValue(), v.getIncrement.longValue())))
+
+  override def incrEx(key: K, amount: Long, args: IncrexArgs): F[IncrexResult[Long]] =
+    async.flatMap(
+      _.increx(key, amount, toJIncrexArgs(args)).futureLift
+        .map(v => IncrexResult(v.getValue.longValue(), v.getIncrement.longValue()))
+    )
+
+  override def incrExFloat(key: K, amount: Double, args: IncrexFloatArgs): F[IncrexResult[Double]] =
+    async.flatMap(
+      _.increx(key, amount, toJIncrexFloatArgs(args)).futureLift
+        .map(v => IncrexResult(v.getValue.doubleValue(), v.getIncrement.doubleValue()))
+    )
+
   override def get(key: K): F[Option[V]] =
     async.flatMap(_.get(key).futureLift.map(Option.apply))
 
@@ -874,6 +929,42 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def strLen(key: K): F[Long] =
     async.flatMap(_.strlen(key).futureLift.map(x => Long.unbox(x)))
 
+  private def toLcsMatch(withMatchLen: Boolean)(m: JStringMatchResult.MatchedPosition): LcsMatch =
+    LcsMatch(
+      LcsMatchPosition(m.getA.getStart, m.getA.getEnd),
+      LcsMatchPosition(m.getB.getStart, m.getB.getEnd),
+      // matchLen is a Java primitive long (always 0 when WITHMATCHLEN wasn't requested) rather than a
+      // nullable field, so — same as GeoSearchResult — Option-ness is decided from what was actually
+      // requested, not inferred from the value.
+      if (withMatchLen) Some(m.getMatchLen) else None
+    )
+
+  private def toLcsResult(withMatchLen: Boolean)(r: JStringMatchResult): LcsResult =
+    LcsResult(
+      Option(r.getMatchString),
+      r.getMatches.asScala.toList.map(toLcsMatch(withMatchLen)),
+      r.getLen
+    )
+
+  // Lettuce's LcsArgs.Builder.keys(String...) takes raw key names rather than K-encoded values (it
+  // calls CommandArgs.add(String), not addKey(K)) — a Lettuce API limitation, not a redis4cats one.
+  // key.toString only produces the correct Redis key when K's toString matches its actual encoded
+  // text, which holds for the common String/UTF8 codec but isn't guaranteed for an arbitrary K.
+  override def lcs(key1: K, key2: K): F[LcsResult] =
+    async.flatMap(
+      _.lcs(JLcsArgs.Builder.keys(key1.toString, key2.toString)).futureLift.map(toLcsResult(withMatchLen = false))
+    )
+
+  override def lcsLen(key1: K, key2: K): F[Long] =
+    async.flatMap(_.lcs(JLcsArgs.Builder.keys(key1.toString, key2.toString).justLen()).futureLift.map(_.getLen))
+
+  override def lcsIdx(key1: K, key2: K, minMatchLen: Option[Int], withMatchLen: Boolean): F[LcsResult] = {
+    val jArgs = JLcsArgs.Builder.keys(key1.toString, key2.toString).withIdx()
+    minMatchLen.foreach(jArgs.minMatchLen)
+    if (withMatchLen) jArgs.withMatchLen(): Unit
+    async.flatMap(_.lcs(jArgs).futureLift.map(toLcsResult(withMatchLen)))
+  }
+
   override def mGet(keys: Set[K]): F[Map[K, V]] =
     async
       .flatMap(_.mget(keys.toSeq: _*).futureLift)
@@ -884,6 +975,24 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def mSetNx(keyValues: Map[K, V]): F[Boolean] =
     async.flatMap(_.msetnx(keyValues.asJava).futureLift.map(x => Boolean.box(x)))
+
+  override def msetEx(keyValues: Map[K, V], args: MSetExArgs): F[Boolean] = {
+    val jArgs = new JMSetExArgs()
+
+    args.ttl.foreach {
+      case MSetExTtl.Ex(d)    => jArgs.ex(java.time.Duration.ofMillis(d.toMillis))
+      case MSetExTtl.Px(d)    => jArgs.px(java.time.Duration.ofMillis(d.toMillis))
+      case MSetExTtl.ExAt(at) => jArgs.exAt(at)
+      case MSetExTtl.PxAt(at) => jArgs.pxAt(at)
+      case MSetExTtl.KeepTtl  => jArgs.keepttl()
+    }
+    args.existence.foreach {
+      case SetArg.Existence.Nx => jArgs.nx()
+      case SetArg.Existence.Xx => jArgs.xx()
+    }
+
+    async.flatMap(_.msetex(keyValues.asJava, jArgs).futureLift.map(x => Boolean.box(x)))
+  }
 
   /** ***************************** JSON API *********************************
     */
@@ -1588,6 +1697,18 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def bitOpXor(destination: K, source: K, sources: K*): F[Long] =
     async.flatMap(_.bitopXor(destination, (source +: sources): _*).futureLift.map(x => Long.box(x)))
+
+  override def bitOpDiff(destination: K, source: K, keys: K*): F[Long] =
+    async.flatMap(_.bitopDiff(destination, source, keys: _*).futureLift.map(x => Long.box(x)))
+
+  override def bitOpDiff1(destination: K, source: K, keys: K*): F[Long] =
+    async.flatMap(_.bitopDiff1(destination, source, keys: _*).futureLift.map(x => Long.box(x)))
+
+  override def bitOpAndOr(destination: K, source: K, keys: K*): F[Long] =
+    async.flatMap(_.bitopAndor(destination, source, keys: _*).futureLift.map(x => Long.box(x)))
+
+  override def bitOpOne(destination: K, keys: K*): F[Long] =
+    async.flatMap(_.bitopOne(destination, keys: _*).futureLift.map(x => Long.box(x)))
 
   override def getBit(key: K, offset: Long): F[Option[Long]] =
     async.flatMap(_.getbit(key, offset).futureLift.map(x => Option(Long.unbox(x))))

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -939,12 +939,15 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
       if (withMatchLen) Some(m.getMatchLen) else None
     )
 
-  private def toLcsResult(withMatchLen: Boolean)(r: JStringMatchResult): LcsResult =
-    LcsResult(
-      Option(r.getMatchString),
-      r.getMatches.asScala.toList.map(toLcsMatch(withMatchLen)),
-      r.getLen
-    )
+  // Redis's plain (non-LEN, non-IDX) LCS reply is just the matched string - no length field at all
+  // on the wire - so Lettuce's StringMatchResult.getLen() defaults to 0 in that mode, not the actual
+  // length. LEN/IDX replies do carry a real length. isIdx tells us which reply shape we're decoding;
+  // the plain case derives len from the matched string we do have, rather than trusting an unset 0.
+  private def toLcsResult(isIdx: Boolean, withMatchLen: Boolean)(r: JStringMatchResult): LcsResult = {
+    val matchString = Option(r.getMatchString)
+    val len         = if (isIdx) r.getLen else matchString.fold(0L)(_.length.toLong)
+    LcsResult(matchString, r.getMatches.asScala.toList.map(toLcsMatch(withMatchLen)), len)
+  }
 
   // Lettuce's LcsArgs.Builder.keys(String...) takes raw key names rather than K-encoded values (it
   // calls CommandArgs.add(String), not addKey(K)) — a Lettuce API limitation, not a redis4cats one.
@@ -952,7 +955,8 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   // text, which holds for the common String/UTF8 codec but isn't guaranteed for an arbitrary K.
   override def lcs(key1: K, key2: K): F[LcsResult] =
     async.flatMap(
-      _.lcs(JLcsArgs.Builder.keys(key1.toString, key2.toString)).futureLift.map(toLcsResult(withMatchLen = false))
+      _.lcs(JLcsArgs.Builder.keys(key1.toString, key2.toString)).futureLift
+        .map(toLcsResult(isIdx = false, withMatchLen = false))
     )
 
   override def lcsLen(key1: K, key2: K): F[Long] =
@@ -962,7 +966,7 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     val jArgs = JLcsArgs.Builder.keys(key1.toString, key2.toString).withIdx()
     minMatchLen.foreach(jArgs.minMatchLen)
     if (withMatchLen) jArgs.withMatchLen(): Unit
-    async.flatMap(_.lcs(jArgs).futureLift.map(toLcsResult(withMatchLen)))
+    async.flatMap(_.lcs(jArgs).futureLift.map(toLcsResult(isIdx = true, withMatchLen)))
   }
 
   override def mGet(keys: Set[K]): F[Map[K, V]] =

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -1046,6 +1046,27 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assertEquals(number, 23065))
       pos <- redis.bitPos(key, state = false)
       _ <- IO(assertEquals(pos, 4.toLong))
+      // New BITOP variants: keyA = bits {0,1} set, keyB = bits {1,2} set (bit1 shared, 0/2 each unique)
+      _ <- redis.setBit("bitop-a", 0, 1)
+      _ <- redis.setBit("bitop-a", 1, 1)
+      _ <- redis.setBit("bitop-b", 1, 1)
+      _ <- redis.setBit("bitop-b", 2, 1)
+      diffLen <- redis.bitOpDiff("bitop-diff", "bitop-a", "bitop-b")
+      _ <- IO(assertEquals(diffLen, 1L))
+      diffBits <- List(0, 1, 2).traverse(redis.getBit("bitop-diff", _))
+      _ <- IO(assertEquals(diffBits, List(Some(1L), Some(0L), Some(0L)))) // only bit0 (unique to A) survives
+      diff1Len <- redis.bitOpDiff1("bitop-diff1", "bitop-a", "bitop-b")
+      _ <- IO(assertEquals(diff1Len, 1L))
+      diff1Bits <- List(0, 1, 2).traverse(redis.getBit("bitop-diff1", _))
+      _ <- IO(assertEquals(diff1Bits, List(Some(0L), Some(0L), Some(1L)))) // only bit2 (unique to B) survives
+      andOrLen <- redis.bitOpAndOr("bitop-andor", "bitop-a", "bitop-b")
+      _ <- IO(assertEquals(andOrLen, 1L))
+      andOrBits <- List(0, 1, 2).traverse(redis.getBit("bitop-andor", _))
+      _ <- IO(assertEquals(andOrBits, List(Some(0L), Some(1L), Some(0L)))) // only bit1 (shared) survives
+      oneLen <- redis.bitOpOne("bitop-one", "bitop-a", "bitop-b")
+      _ <- IO(assertEquals(oneLen, 1L))
+      oneBits <- List(0, 1, 2).traverse(redis.getBit("bitop-one", _))
+      _ <- IO(assertEquals(oneBits, List(Some(1L), Some(0L), Some(1L)))) // bits in exactly one key: 0 and 2
     } yield ()
   }
 
@@ -1124,6 +1145,66 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assertEquals(setRangeLen, 11L))
       setRangeVal <- redis.get("append-key")
       _ <- IO(assertEquals(setRangeVal, Some("Hello Redis")))
+      // LCS: the canonical Redis docs example ("ohmytext" vs "mynewtext" -> "mytext", len 6)
+      _ <- redis.set("lcs-key1", "ohmytext")
+      _ <- redis.set("lcs-key2", "mynewtext")
+      lcsPlain <- redis.lcs("lcs-key1", "lcs-key2")
+      _ <- IO(assertEquals(lcsPlain.matchString, Some("mytext")))
+      _ <- IO(assertEquals(lcsPlain.len, 6L))
+      _ <- IO(assert(lcsPlain.matches.isEmpty)) // idx not requested
+      lcsLen <- redis.lcsLen("lcs-key1", "lcs-key2")
+      _ <- IO(assertEquals(lcsLen, 6L))
+      lcsIdx <- redis.lcsIdx("lcs-key1", "lcs-key2")
+      _ <- IO(assertEquals(lcsIdx.matchString, None)) // idx mode doesn't return the match string
+      _ <- IO(assertEquals(lcsIdx.len, 6L))
+      _ <- IO(
+             assertEquals(
+               lcsIdx.matches,
+               List(
+                 LcsMatch(LcsMatchPosition(4, 7), LcsMatchPosition(5, 8), None),
+                 LcsMatch(LcsMatchPosition(2, 3), LcsMatchPosition(0, 1), None)
+               )
+             )
+           )
+      lcsIdxMinLen <- redis.lcsIdx("lcs-key1", "lcs-key2", minMatchLen = Some(4))
+      _ <- IO(assertEquals(lcsIdxMinLen.matches, List(LcsMatch(LcsMatchPosition(4, 7), LcsMatchPosition(5, 8), None))))
+      lcsIdxWithMatchLen <- redis.lcsIdx("lcs-key1", "lcs-key2", withMatchLen = true)
+      _ <- IO(
+             assertEquals(
+               lcsIdxWithMatchLen.matches,
+               List(
+                 LcsMatch(LcsMatchPosition(4, 7), LcsMatchPosition(5, 8), Some(4L)),
+                 LcsMatch(LcsMatchPosition(2, 3), LcsMatchPosition(0, 1), Some(2L))
+               )
+             )
+           )
+      // msetEx: atomic multi-key SET with a shared TTL
+      msetExOk <-
+        redis.msetEx(Map("msetex-a" -> "1", "msetex-b" -> "2"), MSetExArgs(ttl = Some(MSetExTtl.Ex(10.seconds))))
+      _ <- IO(assert(msetExOk))
+      msetExVals <- redis.mGet(Set("msetex-a", "msetex-b"))
+      _ <- IO(assertEquals(msetExVals, Map("msetex-a" -> "1", "msetex-b" -> "2")))
+      msetExTtl <- redis.ttl("msetex-a")
+      _ <- IO(assert(msetExTtl.nonEmpty))
+      // msetEx with NX: fails atomically (no key written) if any target key already exists
+      msetExNxBlocked <-
+        redis.msetEx(Map("msetex-a" -> "3", "msetex-c" -> "4"), MSetExArgs(existence = Some(SetArg.Existence.Nx)))
+      _ <- IO(assert(!msetExNxBlocked))
+      msetExCAfter <- redis.get("msetex-c")
+      _ <- IO(assert(msetExCAfter.isEmpty)) // the whole op was rejected, not just the conflicting key
+      // incrEx: plain form behaves like INCR on a fresh key
+      incrExPlain <- redis.incrEx("increx-key")
+      _ <- IO(assertEquals(incrExPlain, IncrexResult(1L, 1L)))
+      incrExBy5 <- redis.incrEx("increx-key", 5L, IncrexArgs())
+      _ <- IO(assertEquals(incrExBy5, IncrexResult(6L, 5L)))
+      // saturate: 6 + 100 would exceed upperBound=10, so the result clamps and the applied increment differs
+      incrExSaturated <- redis.incrEx("increx-key", 100L, IncrexArgs(upperBound = Some(10L), saturate = true))
+      _ <- IO(assertEquals(incrExSaturated, IncrexResult(10L, 4L)))
+      _ <- redis.incrEx("increx-key-ttl", 1L, IncrexArgs(ttl = Some(IncrexTtl.Ex(10.seconds))))
+      incrExTtl <- redis.ttl("increx-key-ttl")
+      _ <- IO(assert(incrExTtl.nonEmpty))
+      incrExFloatRes <- redis.incrExFloat("increx-float-key", 1.5, IncrexFloatArgs())
+      _ <- IO(assertEquals(incrExFloatRes, IncrexResult(1.5, 1.5)))
     } yield ()
   }
 


### PR DESCRIPTION
Part of the broader command-coverage audit against Lettuce 7.7.0. This work was actually done earlier in this effort but got stuck: `INCREX`/`MSETEX` were briefly suspected to be Redis-8.10-gated (matching the exact pattern hit by `SUNIONCARD`/`LMOVEM` in #1183/#1185) and a revert was started but never finished or pushed. Verified empirically against a real `redis:8.10.1` container: both commands are recognized (no `ERR unknown command`) - the suspicion was wrong, so the revert-in-progress was discarded and the original work restored.

**Added:**
- `lcs`/`lcsLen`/`lcsIdx` (LCS command family) - new `LcsResult`/`LcsMatch`/`LcsMatchPosition` types
- New `BITOP` variants: `bitOpDiff`/`bitOpDiff1`/`bitOpAndOr`/`bitOpOne`
- `incrEx`/`incrExFloat` - new `IncrexArgs`/`IncrexFloatArgs`/`IncrexResult`/`IncrexTtl` types
- `msetEx` - new `MSetExArgs`/`MSetExTtl` types

**Real bug found and fixed while getting this worktree's own test suite to actually pass for the first time** (it had never been run against real Redis before, since the branch was abandoned mid-revert): `lcs()`'s plain (non-`LEN`, non-`IDX`) call always reported `len = 0` regardless of the real match length. Redis's plain `LCS key1 key2` reply is just the matched string - there's no length field on the wire in that mode at all, only `LEN`/`IDX` replies carry one. Lettuce's shared `StringMatchResult.getLen()` defaults to 0 when the server didn't send a value, and the code trusted it uncritically for every call shape. Fixed by deriving `len` from the matched string's own length for the plain case, and only trusting Lettuce's `getLen()` for the `LEN`/`IDX` replies where the server actually reports it.

Also noted but not changed: `LcsArgs.Builder.keys(String, String)` is a genuine Lettuce API limitation - it takes raw key names rather than `K`-encoded values, so `key.toString` only produces the correct Redis key when `K`'s `toString` matches its actual encoded text (holds for the common String/UTF8 codec, not guaranteed for an arbitrary `K`). Documented inline; same category of accepted Lettuce quirk as the `GeoSearch.fromMember` codec issue from #1180.

## Test plan
- [x] `sbt compile` + `Test/compile` - clean
- [x] `sbt mdoc` - clean
- [x] `RedisSpec` + `RedisClusterSpec` both green (36/36) against a real `redis:8.10.1` + `yisraelu/redis-cluster:8.10.1` cluster
- [x] Verified empirically (real `redis-cli` against `redis:8.10.1`) that `INCREX`/`MSETEX` are recognized commands before restoring them