### PR TITLE
series/3.x: close streams command-coverage gap (XINFO STREAM/GROUPS/CONSUMERS, XDELEX, XACKDEL, XNACK, XCFGSET)

### DIFF
--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
@@ -74,10 +74,7 @@ trait StreamSetter[F[_], K, V] {
     */
   def xDelEx(key: K, ids: String*): F[List[StreamEntryDeletionResult]]
 
-  /** `XDELEX` with explicit control over what happens to consumer-group PEL references to the deleted entries. A
-    * defaulted `policy` parameter can't precede a varargs `ids` and still be skippable at a normal (unnamed) call site,
-    * hence the separate overload rather than a default value on the method above.
-    */
+  /** `XDELEX` with explicit control over what happens to consumer-group PEL references to the deleted entries. */
   def xDelEx(key: K, policy: StreamDeletionPolicy, ids: String*): F[List[StreamEntryDeletionResult]]
 
   /** `XCFGSET` - sets stream-level idempotent-publish configuration (see [[XCfgSetArgs]]). */
@@ -120,9 +117,7 @@ trait StreamConsumerGroups[F[_], K, V] {
     */
   def xAckDel(key: K, group: K, ids: String*): F[List[StreamEntryDeletionResult]]
 
-  /** `XACKDEL` with explicit control over the deletion policy - see [[xDelEx]]'s two-overload note for why this isn't a
-    * defaulted parameter instead.
-    */
+  /** `XACKDEL` with explicit control over the deletion policy. */
   def xAckDel(key: K, group: K, policy: StreamDeletionPolicy, ids: String*): F[List[StreamEntryDeletionResult]]
 
   /** `XNACK` - negatively-acknowledges messages in `group`'s Pending Entries List, adjusting their delivery counter per

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
@@ -68,15 +68,17 @@ trait StreamSetter[F[_], K, V] {
   def xTrim(key: K, args: XTrimArgs): F[Long]
   def xDel(key: K, ids: String*): F[Long]
 
-  /** `XDELEX` - like [[xDel]], but with control over what happens to consumer-group PEL references to the deleted
-    * entries (`policy` defaults to `StreamDeletionPolicy.KeepReferences`, matching plain `XDEL`). Returns the per-id
-    * outcome, in the same order as `ids`.
+  /** `XDELEX` - like [[xDel]], but reports the per-id outcome (in the same order as `ids`) instead of just a count.
+    * Uses `StreamDeletionPolicy.KeepReferences`, matching plain `XDEL`'s behavior - use the `policy` overload to choose
+    * a different one.
     */
-  def xDelEx(
-      key: K,
-      policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepReferences,
-      ids: String*
-  ): F[List[StreamEntryDeletionResult]]
+  def xDelEx(key: K, ids: String*): F[List[StreamEntryDeletionResult]]
+
+  /** `XDELEX` with explicit control over what happens to consumer-group PEL references to the deleted entries. A
+    * defaulted `policy` parameter can't precede a varargs `ids` and still be skippable at a normal (unnamed) call site,
+    * hence the separate overload rather than a default value on the method above.
+    */
+  def xDelEx(key: K, policy: StreamDeletionPolicy, ids: String*): F[List[StreamEntryDeletionResult]]
 
   /** `XCFGSET` - sets stream-level idempotent-publish configuration (see [[XCfgSetArgs]]). */
   def xCfgSet(key: K, args: XCfgSetArgs): F[Unit]
@@ -113,15 +115,15 @@ trait StreamConsumerGroups[F[_], K, V] {
 
   def xAck(key: K, group: K, ids: String*): F[Long]
 
-  /** `XACKDEL` - atomically combines [[xAck]] with an [[xDelEx]]-style deletion (`policy` defaults to
-    * `StreamDeletionPolicy.KeepReferences`). Returns the per-id deletion outcome, in the same order as `ids`.
+  /** `XACKDEL` - atomically combines [[xAck]] with an [[xDelEx]]-style deletion, using
+    * `StreamDeletionPolicy.KeepReferences`. Returns the per-id deletion outcome, in the same order as `ids`.
     */
-  def xAckDel(
-      key: K,
-      group: K,
-      policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepReferences,
-      ids: String*
-  ): F[List[StreamEntryDeletionResult]]
+  def xAckDel(key: K, group: K, ids: String*): F[List[StreamEntryDeletionResult]]
+
+  /** `XACKDEL` with explicit control over the deletion policy - see [[xDelEx]]'s two-overload note for why this isn't a
+    * defaulted parameter instead.
+    */
+  def xAckDel(key: K, group: K, policy: StreamDeletionPolicy, ids: String*): F[List[StreamEntryDeletionResult]]
 
   /** `XNACK` - negatively-acknowledges messages in `group`'s Pending Entries List, adjusting their delivery counter per
     * `mode` without acknowledging or removing them. Returns the number of entries affected.

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/algebra/streams.scala
@@ -19,17 +19,24 @@ package dev.profunktor.redis4cats.algebra
 import dev.profunktor.redis4cats.effects.{
   MessageId,
   StreamConsumer,
+  StreamDeletionPolicy,
+  StreamEntryDeletionResult,
   StreamMessage,
   XAddArgs,
   XAutoClaimArgs,
   XAutoClaimResult,
+  XCfgSetArgs,
   XClaimArgs,
+  XConsumerInfo,
   XGroupCreateArgs,
+  XGroupInfo,
+  XNackMode,
   XPendingMessage,
   XPendingSummary,
   XRangePoint,
   XReadGroupArgs,
   XReadOffsets,
+  XStreamInfo,
   XTrimArgs
 }
 
@@ -50,6 +57,9 @@ trait StreamGetter[F[_], K, V] {
   def xRange(key: K, start: XRangePoint, end: XRangePoint, count: Option[Long] = None): F[List[StreamMessage[K, V]]]
   def xRevRange(key: K, start: XRangePoint, end: XRangePoint, count: Option[Long] = None): F[List[StreamMessage[K, V]]]
   def xLen(key: K): F[Long]
+
+  /** `XINFO STREAM` - general information about a stream. */
+  def xInfoStream(key: K): F[XStreamInfo[K, V]]
 }
 
 trait StreamSetter[F[_], K, V] {
@@ -57,6 +67,19 @@ trait StreamSetter[F[_], K, V] {
   def xAdd(key: K, body: Map[K, V], args: XAddArgs = XAddArgs()): F[MessageId]
   def xTrim(key: K, args: XTrimArgs): F[Long]
   def xDel(key: K, ids: String*): F[Long]
+
+  /** `XDELEX` - like [[xDel]], but with control over what happens to consumer-group PEL references to the deleted
+    * entries (`policy` defaults to `StreamDeletionPolicy.KeepReferences`, matching plain `XDEL`). Returns the per-id
+    * outcome, in the same order as `ids`.
+    */
+  def xDelEx(
+      key: K,
+      policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepReferences,
+      ids: String*
+  ): F[List[StreamEntryDeletionResult]]
+
+  /** `XCFGSET` - sets stream-level idempotent-publish configuration (see [[XCfgSetArgs]]). */
+  def xCfgSet(key: K, args: XCfgSetArgs): F[Unit]
 }
 
 /** Consumer-group commands for Redis Streams (the `XGROUP`/`XREADGROUP`/`XACK`/`XCLAIM`/`XPENDING` family).
@@ -76,6 +99,12 @@ trait StreamConsumerGroups[F[_], K, V] {
   def xGroupCreateConsumer(key: K, consumer: StreamConsumer[K]): F[Boolean]
   def xGroupDelConsumer(key: K, consumer: StreamConsumer[K]): F[Long]
 
+  /** `XINFO GROUPS` - one entry per consumer group registered on the stream. */
+  def xInfoGroups(key: K): F[List[XGroupInfo]]
+
+  /** `XINFO CONSUMERS` - one entry per consumer registered on the given group. */
+  def xInfoConsumers(key: K, group: K): F[List[XConsumerInfo]]
+
   def xReadGroup(
       consumer: StreamConsumer[K],
       streams: Set[XReadOffsets[K]],
@@ -83,6 +112,24 @@ trait StreamConsumerGroups[F[_], K, V] {
   ): F[List[StreamMessage[K, V]]]
 
   def xAck(key: K, group: K, ids: String*): F[Long]
+
+  /** `XACKDEL` - atomically combines [[xAck]] with an [[xDelEx]]-style deletion (`policy` defaults to
+    * `StreamDeletionPolicy.KeepReferences`). Returns the per-id deletion outcome, in the same order as `ids`.
+    */
+  def xAckDel(
+      key: K,
+      group: K,
+      policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepReferences,
+      ids: String*
+  ): F[List[StreamEntryDeletionResult]]
+
+  /** `XNACK` - negatively-acknowledges messages in `group`'s Pending Entries List, adjusting their delivery counter per
+    * `mode` without acknowledging or removing them. Returns the number of entries affected.
+    *
+    * Lettuce also exposes a single-id overload; it's not mirrored here since this varargs form already covers that call
+    * shape (`xNack(key, group, mode, id)`).
+    */
+  def xNack(key: K, group: K, mode: XNackMode, ids: String*): F[Long]
 
   def xClaim(
       key: K,

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -889,6 +889,72 @@ object effects {
       lastEntry: Option[StreamMessage[K, V]],
       extra: Map[String, String] = Map.empty
   )
+  object XStreamInfo {
+    import dev.profunktor.redis4cats.JavaConversions._
+
+    private val knownFields = Set(
+      "length",
+      "radix-tree-keys",
+      "radix-tree-nodes",
+      "last-generated-id",
+      "max-deleted-entry-id",
+      "entries-added",
+      "recorded-first-entry-id",
+      "groups",
+      "first-entry",
+      "last-entry"
+    )
+
+    // A first-entry/last-entry value is Lettuce's untyped stand-in for a StreamMessage: [id, [field, value, ...]].
+    // The K/V pairs have already passed through the connection's codec by the time they reach us as Object - the
+    // cast here is exactly as safe as the one Lettuce's own typed StreamMessage[K, V] getters perform internally,
+    // just visible instead of hidden behind a generic type parameter.
+    private def toEntry[K, V](key: K, raw: Any): StreamMessage[K, V] =
+      raw match {
+        case entry: java.util.List[_] =>
+          entry.asScala.toList match {
+            case (id: String) :: (fields: java.util.List[_]) :: Nil =>
+              val body = fields.asScala.toList
+                .grouped(2)
+                .collect { case (k: Any) :: (v: Any) :: Nil => k.asInstanceOf[K] -> v.asInstanceOf[V] }
+                .toMap
+              StreamMessage(MessageId(id), key, body)
+            case other => throw XInfoError.UnexpectedStreamInfoReply(other.toString)
+          }
+        case other => throw XInfoError.UnexpectedStreamInfoReply(other.toString)
+      }
+
+    /** Decodes `XINFO STREAM`'s reply - a flat, untyped `List[Object]` of alternating field-name/value pairs. */
+    private[redis4cats] def fromLettuce[K, V](key: K, reply: java.util.List[Object]): XStreamInfo[K, V] = {
+      def fail                 = throw XInfoError.UnexpectedStreamInfoReply(reply.toString)
+      def asLong(a: Any): Long = a.toString.toLong
+
+      val fields = reply.asScala.toList
+        .grouped(2)
+        .collect { case (name: String) :: value :: Nil => name -> value }
+        .toMap
+
+      def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
+      // Redis reports an empty stream's first-entry/last-entry as a nil reply, which the field map above
+      // stores as a present key with a null value rather than a missing key - Option(_) collapses that null
+      // to None, same as Map.get already does for a genuinely absent key.
+      def optional[A](name: String)(f: Any => A): Option[A] = fields.get(name).flatMap(Option(_)).map(f)
+
+      XStreamInfo[K, V](
+        length = required("length")(asLong),
+        radixTreeKeys = required("radix-tree-keys")(asLong),
+        radixTreeNodes = required("radix-tree-nodes")(asLong),
+        lastGeneratedId = required("last-generated-id")(v => MessageId(v.toString)),
+        maxDeletedEntryId = required("max-deleted-entry-id")(v => MessageId(v.toString)),
+        entriesAdded = required("entries-added")(asLong),
+        recordedFirstEntryId = required("recorded-first-entry-id")(v => MessageId(v.toString)),
+        groups = required("groups")(asLong),
+        firstEntry = optional("first-entry")(toEntry(key, _)),
+        lastEntry = optional("last-entry")(toEntry(key, _)),
+        extra = fields.collect { case (k, v) if !knownFields.contains(k) => k -> v.toString }
+      )
+    }
+  }
 
   /** One entry of an `XINFO GROUPS` reply. `entriesRead`/`lag` are `None` when Redis cannot determine them (e.g. right
     * after `XGROUP CREATE`/`XSETID`, before anything has been read).
@@ -901,6 +967,34 @@ object effects {
       entriesRead: Option[Long],
       lag: Option[Long]
   )
+  object XGroupInfo {
+    import dev.profunktor.redis4cats.JavaConversions._
+
+    /** Decodes one element of `XINFO GROUPS`' reply - a flat, untyped `List[Object]` of field-name/value pairs.
+      * `entries-read`/`lag` are null when Redis can't compute them yet (e.g. right after `XGROUP CREATE`/`XSETID`).
+      */
+    private[redis4cats] def fromLettuce(raw: Any): XGroupInfo = {
+      def fail = throw XInfoError.UnexpectedGroupInfoReply(raw.toString)
+      raw match {
+        case entry: java.util.List[_] =>
+          val fields: Map[String, Any] = entry.asScala.toList
+            .grouped(2)
+            .collect { case (name: String) :: value :: Nil => name -> value }
+            .toMap
+          def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
+          def optionalLong(name: String): Option[Long]  = fields.get(name).flatMap(Option(_)).map(_.toString.toLong)
+          XGroupInfo(
+            name = required("name")(_.toString),
+            consumers = required("consumers")(_.toString.toLong),
+            pending = required("pending")(_.toString.toLong),
+            lastDeliveredId = required("last-delivered-id")(v => MessageId(v.toString)),
+            entriesRead = optionalLong("entries-read"),
+            lag = optionalLong("lag")
+          )
+        case _ => fail
+      }
+    }
+  }
 
   /** One entry of an `XINFO CONSUMERS` reply. `inactive` (time since the consumer's last successful command, distinct
     * from `idle` - time since its last attempted read) was added in Redis 7.2; `None` on servers that don't report it.
@@ -911,6 +1005,35 @@ object effects {
       idle: FiniteDuration,
       inactive: Option[FiniteDuration]
   )
+  object XConsumerInfo {
+    import dev.profunktor.redis4cats.JavaConversions._
+
+    /** Decodes one element of `XINFO CONSUMERS`' reply - a flat, untyped `List[Object]` of field-name/value pairs.
+      * `inactive` (time since the consumer's last successful command, distinct from `idle` - time since its last
+      * attempted read) was added in Redis 7.2; `None` on servers that don't report it.
+      */
+    private[redis4cats] def fromLettuce(raw: Any): XConsumerInfo = {
+      def fail = throw XInfoError.UnexpectedConsumerInfoReply(raw.toString)
+      raw match {
+        case entry: java.util.List[_] =>
+          val fields: Map[String, Any] = entry.asScala.toList
+            .grouped(2)
+            .collect { case (name: String) :: value :: Nil => name -> value }
+            .toMap
+          def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
+          XConsumerInfo(
+            name = required("name")(_.toString),
+            pending = required("pending")(_.toString.toLong),
+            idle = required("idle")(v => FiniteDuration(v.toString.toLong, TimeUnit.MILLISECONDS)),
+            inactive = fields
+              .get("inactive")
+              .flatMap(Option(_))
+              .map(v => FiniteDuration(v.toString.toLong, TimeUnit.MILLISECONDS))
+          )
+        case _ => fail
+      }
+    }
+  }
 
   /** Failure raised while decoding an `XINFO STREAM`/`XINFO GROUPS`/`XINFO CONSUMERS` reply. Lettuce hands these back
     * as untyped, flat key-value `List[Object]`s with no schema enforcement - a genuinely unexpected shape becomes one

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/effects.scala
@@ -868,6 +868,124 @@ object effects {
       messages: List[StreamMessage[K, V]]
   )
 
+  /** Reply to `XINFO STREAM`. `firstEntry`/`lastEntry` are `None` when the stream currently holds no entries (Redis
+    * reports them as a null reply in that case, per its own docs). `extra` carries any key/value pairs beyond the
+    * well-established ones as flat strings - as of Redis 8.10 that includes a handful of idempotent-publish bookkeeping
+    * fields (`idmp-duration`, `idmp-maxsize`, `pids-tracked`, `iids-tracked`, `iids-added`, `iids-duplicates`)
+    * introduced alongside `XCFGSET`. Those are still new/evolving as of this writing, so rather than freeze their exact
+    * names/shape into named fields, they land in `extra` - nothing Lettuce hands back is silently dropped, without
+    * over-committing this type to an unstable surface.
+    */
+  final case class XStreamInfo[K, V](
+      length: Long,
+      radixTreeKeys: Long,
+      radixTreeNodes: Long,
+      lastGeneratedId: MessageId,
+      maxDeletedEntryId: MessageId,
+      entriesAdded: Long,
+      recordedFirstEntryId: MessageId,
+      groups: Long,
+      firstEntry: Option[StreamMessage[K, V]],
+      lastEntry: Option[StreamMessage[K, V]],
+      extra: Map[String, String] = Map.empty
+  )
+
+  /** One entry of an `XINFO GROUPS` reply. `entriesRead`/`lag` are `None` when Redis cannot determine them (e.g. right
+    * after `XGROUP CREATE`/`XSETID`, before anything has been read).
+    */
+  final case class XGroupInfo(
+      name: String,
+      consumers: Long,
+      pending: Long,
+      lastDeliveredId: MessageId,
+      entriesRead: Option[Long],
+      lag: Option[Long]
+  )
+
+  /** One entry of an `XINFO CONSUMERS` reply. `inactive` (time since the consumer's last successful command, distinct
+    * from `idle` - time since its last attempted read) was added in Redis 7.2; `None` on servers that don't report it.
+    */
+  final case class XConsumerInfo(
+      name: String,
+      pending: Long,
+      idle: FiniteDuration,
+      inactive: Option[FiniteDuration]
+  )
+
+  /** Failure raised while decoding an `XINFO STREAM`/`XINFO GROUPS`/`XINFO CONSUMERS` reply. Lettuce hands these back
+    * as untyped, flat key-value `List[Object]`s with no schema enforcement - a genuinely unexpected shape becomes one
+    * of these instead of a `ClassCastException`/`NoSuchElementException` deep inside a fold.
+    */
+  sealed abstract class XInfoError(message: String) extends RuntimeException(message)
+  object XInfoError {
+    final case class UnexpectedStreamInfoReply(reply: String)
+        extends XInfoError(s"Unexpected XINFO STREAM reply: $reply")
+    final case class UnexpectedGroupInfoReply(reply: String)
+        extends XInfoError(s"Unexpected XINFO GROUPS entry: $reply")
+    final case class UnexpectedConsumerInfoReply(reply: String)
+        extends XInfoError(s"Unexpected XINFO CONSUMERS entry: $reply")
+  }
+
+  /** Which stream entries `XDELEX`/`XACKDEL` are allowed to remove, and how they treat consumer-group PEL references to
+    * them. Mirrors Lettuce's `StreamDeletionPolicy`, modelled as our own ADT since that type is marked `@Experimental`
+    * upstream. Redis defaults to [[KeepReferences]] when none is given - the same behavior as plain `XDEL`.
+    */
+  sealed trait StreamDeletionPolicy
+  object StreamDeletionPolicy {
+
+    /** `KEEPREF` (default): delete the entry but leave any consumer-group PEL references to it in place. */
+    case object KeepReferences extends StreamDeletionPolicy
+
+    /** `DELREF`: delete the entry and remove all consumer-group PEL references to it. */
+    case object DeleteReferences extends StreamDeletionPolicy
+
+    /** `ACKED`: only delete entries that have already been read and acknowledged by every consumer group. */
+    case object Acknowledged extends StreamDeletionPolicy
+  }
+
+  /** Per-id outcome of `XDELEX`/`XACKDEL`. Mirrors Lettuce's `StreamEntryDeletionResult`. */
+  sealed trait StreamEntryDeletionResult
+  object StreamEntryDeletionResult {
+    case object Deleted extends StreamEntryDeletionResult
+    case object NotDeletedUnacknowledgedOrStillReferenced extends StreamEntryDeletionResult
+    case object NotFound extends StreamEntryDeletionResult
+    case object Unknown extends StreamEntryDeletionResult
+  }
+
+  /** How `XNACK` adjusts a message's delivery counter in the consumer group's Pending Entries List. Mirrors Lettuce's
+    * `XNackMode`.
+    */
+  sealed trait XNackMode
+  object XNackMode {
+
+    /** Internal error/shutdown on this consumer - decrements the delivery counter by 1, allowing normal redelivery
+      * elsewhere.
+      */
+    case object Silent extends XNackMode
+
+    /** The message is problematic for this consumer specifically but may succeed elsewhere - delivery counter left
+      * unchanged.
+      */
+    case object Fail extends XNackMode
+
+    /** The message is invalid/malicious - delivery counter is set to `LLONG_MAX`, effectively preventing further
+      * redelivery.
+      */
+    case object Fatal extends XNackMode
+  }
+
+  /** Options for `XCFGSET`, Redis's per-stream idempotent-publish configuration. Both setters are independent -
+    * mirroring Lettuce's `XCfgSetArgs` - and an unset field is left unchanged server-side rather than reset.
+    * @param idempotencyMaxSize
+    *   the maximum number of tracked producer ids to retain (`IDMP-MAXSIZE`)
+    * @param idempotencyDuration
+    *   how long a tracked producer id remains valid, in the unit Redis's own `IDMP-DURATION` argument expects
+    */
+  final case class XCfgSetArgs(
+      idempotencyMaxSize: Option[Long] = None,
+      idempotencyDuration: Option[Long] = None
+  )
+
   implicit class TimePrecisionOps(val duration: FiniteDuration) extends AnyVal {
     def refine: Long = duration.unit match {
       case TimeUnit.MILLISECONDS | TimeUnit.MICROSECONDS | TimeUnit.NANOSECONDS => duration.toMillis

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -2982,6 +2982,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def xDel(key: K, ids: String*): F[Long] =
     async.flatMap(_.xdel(key, ids: _*).futureLift.map(Long.box(_)))
 
+  override def xDelEx(key: K, ids: String*): F[List[StreamEntryDeletionResult]] =
+    async.flatMap(_.xdelex(key, ids: _*).futureLift).map(_.asScala.toList.map(_.asScala))
+
   override def xDelEx(key: K, policy: StreamDeletionPolicy, ids: String*): F[List[StreamEntryDeletionResult]] =
     async
       .flatMap(_.xdelex(key, toJStreamDeletionPolicy(policy), ids: _*).futureLift)
@@ -3053,6 +3056,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def xAck(key: K, group: K, ids: String*): F[Long] =
     async.flatMap(_.xack(key, group, ids: _*).futureLift.map(x => Long.box(x)))
+
+  override def xAckDel(key: K, group: K, ids: String*): F[List[StreamEntryDeletionResult]] =
+    async.flatMap(_.xackdel(key, group, ids: _*).futureLift).map(_.asScala.toList.map(_.asScala))
 
   override def xAckDel(
       key: K,

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -75,14 +75,17 @@ import io.lettuce.core.{
   ScoredValue,
   SetArgs => JSetArgs,
   SortArgs => JSortArgs,
+  StreamDeletionPolicy => JStreamDeletionPolicy,
   StringMatchResult => JStringMatchResult,
   TrackingArgs => JTrackingArgs,
   TrackingInfo => JTrackingInfo,
   UnblockType => JUnblockType,
   XAddArgs => JXAddArgs,
   XAutoClaimArgs => JXAutoClaimArgs,
+  XCfgSetArgs => JXCfgSetArgs,
   XClaimArgs => JXClaimArgs,
   XGroupCreateArgs => JXGroupCreateArgs,
+  XNackMode => JXNackMode,
   XReadArgs,
   XTrimArgs => JXTrimArgs,
   ZAddArgs,
@@ -91,7 +94,12 @@ import io.lettuce.core.{
   ZStoreArgs
 }
 import io.lettuce.core.models.command.{ CommandDetail => JCommandDetail, CommandDetailParser }
-import io.lettuce.core.models.stream.{ ClaimedMessages, PendingMessage, PendingMessages }
+import io.lettuce.core.models.stream.{
+  ClaimedMessages,
+  PendingMessage,
+  PendingMessages,
+  StreamEntryDeletionResult => JStreamEntryDeletionResult
+}
 import io.lettuce.core.protocol.CommandType
 import org.typelevel.keypool.KeyPool
 
@@ -2940,6 +2948,69 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def xLen(key: K): F[Long] =
     async.flatMap(_.xlen(key).futureLift.map(Long.box(_)))
 
+  override def xInfoStream(key: K): F[XStreamInfo[K, V]] =
+    async.flatMap(_.xinfoStream(key).futureLift).flatMap(reply => FutureLift[F].delay(toXStreamInfo(key, reply)))
+
+  // XINFO STREAM comes back from Lettuce as a flat, untyped List[Object]: alternating field-name/value pairs.
+  // first-entry/last-entry are each either null (empty stream) or a nested [id, [field, value, ...]] list - the id
+  // is always a plain String (mirroring core.StreamMessage#getId, which is String regardless of codec), while the
+  // field/value pairs are the actual K/V-decoded message body. Anything beyond the well-known fields (as of Redis
+  // 8.10, a handful of XCFGSET-related idempotency counters) is preserved verbatim in `extra` rather than assumed
+  // away.
+  private val xStreamInfoKnownFields = Set(
+    "length",
+    "radix-tree-keys",
+    "radix-tree-nodes",
+    "last-generated-id",
+    "max-deleted-entry-id",
+    "entries-added",
+    "recorded-first-entry-id",
+    "groups",
+    "first-entry",
+    "last-entry"
+  )
+
+  private def toXStreamInfo(key: K, reply: java.util.List[Object]): XStreamInfo[K, V] = {
+    def fail                 = throw XInfoError.UnexpectedStreamInfoReply(reply.toString)
+    def asLong(a: Any): Long = a.toString.toLong
+
+    def toEntry(raw: Any): StreamMessage[K, V] =
+      raw match {
+        case entry: java.util.List[_] =>
+          entry.asScala.toList match {
+            case (id: String) :: (fields: java.util.List[_]) :: Nil =>
+              val body = fields.asScala.toList
+                .grouped(2)
+                .collect { case (k: Any) :: (v: Any) :: Nil => k.asInstanceOf[K] -> v.asInstanceOf[V] }
+                .toMap
+              StreamMessage(MessageId(id), key, body)
+            case _ => fail
+          }
+        case _ => fail
+      }
+
+    val fields = reply.asScala.toList
+      .grouped(2)
+      .collect { case (name: String) :: value :: Nil => name -> value }
+      .toMap
+
+    def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
+
+    XStreamInfo[K, V](
+      length = required("length")(asLong),
+      radixTreeKeys = required("radix-tree-keys")(asLong),
+      radixTreeNodes = required("radix-tree-nodes")(asLong),
+      lastGeneratedId = required("last-generated-id")(v => MessageId(v.toString)),
+      maxDeletedEntryId = required("max-deleted-entry-id")(v => MessageId(v.toString)),
+      entriesAdded = required("entries-added")(asLong),
+      recordedFirstEntryId = required("recorded-first-entry-id")(v => MessageId(v.toString)),
+      groups = required("groups")(asLong),
+      firstEntry = fields.get("first-entry").flatMap(v => Option(v).map(toEntry)),
+      lastEntry = fields.get("last-entry").flatMap(v => Option(v).map(toEntry)),
+      extra = fields.view.filterKeys(k => !xStreamInfoKnownFields.contains(k)).mapValues(_.toString).toMap
+    )
+  }
+
   override def xAdd(key: K, body: Map[K, V], args: XAddArgs): F[MessageId] = {
     val jArgs = JXAddArgs.Builder.nomkstream()
     jArgs.nomkstream(args.nomkstream)
@@ -2969,6 +3040,25 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def xDel(key: K, ids: String*): F[Long] =
     async.flatMap(_.xdel(key, ids: _*).futureLift.map(Long.box(_)))
 
+  override def xDelEx(key: K, policy: StreamDeletionPolicy, ids: String*): F[List[StreamEntryDeletionResult]] =
+    async
+      .flatMap(_.xdelex(key, toJStreamDeletionPolicy(policy), ids: _*).futureLift)
+      .map(_.asScala.toList.map(_.asScala))
+
+  override def xCfgSet(key: K, args: XCfgSetArgs): F[Unit] = {
+    val jArgs = new JXCfgSetArgs()
+    args.idempotencyMaxSize.foreach(jArgs.idmpMaxsize)
+    args.idempotencyDuration.foreach(jArgs.idmpDuration)
+    async.flatMap(_.xcfgset(key, jArgs).futureLift.void)
+  }
+
+  private def toJStreamDeletionPolicy(policy: StreamDeletionPolicy): JStreamDeletionPolicy =
+    policy match {
+      case StreamDeletionPolicy.KeepReferences   => JStreamDeletionPolicy.KEEP_REFERENCES
+      case StreamDeletionPolicy.DeleteReferences => JStreamDeletionPolicy.DELETE_REFERENCES
+      case StreamDeletionPolicy.Acknowledged     => JStreamDeletionPolicy.ACKNOWLEDGED
+    }
+
   // format: off
   /************************** Stream Consumer Groups API ************************/
   // format: on
@@ -2997,6 +3087,62 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def xGroupDelConsumer(key: K, consumer: StreamConsumer[K]): F[Long] =
     async.flatMap(_.xgroupDelconsumer(key, consumer.asJava).futureLift.map(x => Long.box(x)))
 
+  override def xInfoGroups(key: K): F[List[XGroupInfo]] =
+    async
+      .flatMap(_.xinfoGroups(key).futureLift)
+      .flatMap(reply => FutureLift[F].delay(reply.asScala.toList.map(toXGroupInfo)))
+
+  // Each element of XINFO GROUPS' reply is itself a flat, untyped List[Object] of field-name/value pairs (one per
+  // group) - entries-read/lag are null when Redis can't compute them yet (e.g. right after XGROUP CREATE/XSETID).
+  private def toXGroupInfo(raw: Any): XGroupInfo = {
+    def fail = throw XInfoError.UnexpectedGroupInfoReply(raw.toString)
+    raw match {
+      case entry: java.util.List[_] =>
+        val fields: Map[String, Any] = entry.asScala.toList
+          .grouped(2)
+          .collect { case (name: String) :: value :: Nil => name -> value }
+          .toMap
+        def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
+        def optionalLong(name: String): Option[Long]  = fields.get(name).flatMap(v => Option(v).map(_.toString.toLong))
+        XGroupInfo(
+          name = required("name")(_.toString),
+          consumers = required("consumers")(_.toString.toLong),
+          pending = required("pending")(_.toString.toLong),
+          lastDeliveredId = required("last-delivered-id")(v => MessageId(v.toString)),
+          entriesRead = optionalLong("entries-read"),
+          lag = optionalLong("lag")
+        )
+      case _ => fail
+    }
+  }
+
+  override def xInfoConsumers(key: K, group: K): F[List[XConsumerInfo]] =
+    async
+      .flatMap(_.xinfoConsumers(key, group).futureLift)
+      .flatMap(reply => FutureLift[F].delay(reply.asScala.toList.map(toXConsumerInfo)))
+
+  // Each element of XINFO CONSUMERS' reply is itself a flat, untyped List[Object] of field-name/value pairs (one
+  // per consumer) - `inactive` was added in Redis 7.2, so it's treated as optional for older servers.
+  private def toXConsumerInfo(raw: Any): XConsumerInfo = {
+    def fail = throw XInfoError.UnexpectedConsumerInfoReply(raw.toString)
+    raw match {
+      case entry: java.util.List[_] =>
+        val fields: Map[String, Any] = entry.asScala.toList
+          .grouped(2)
+          .collect { case (name: String) :: value :: Nil => name -> value }
+          .toMap
+        def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
+        XConsumerInfo(
+          name = required("name")(_.toString),
+          pending = required("pending")(_.toString.toLong),
+          idle = required("idle")(v => FiniteDuration(v.toString.toLong, MILLISECONDS)),
+          inactive =
+            fields.get("inactive").flatMap(v => Option(v).map(v => FiniteDuration(v.toString.toLong, MILLISECONDS)))
+        )
+      case _ => fail
+    }
+  }
+
   override def xReadGroup(
       consumer: StreamConsumer[K],
       streams: Set[XReadOffsets[K]],
@@ -3011,6 +3157,26 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
 
   override def xAck(key: K, group: K, ids: String*): F[Long] =
     async.flatMap(_.xack(key, group, ids: _*).futureLift.map(x => Long.box(x)))
+
+  override def xAckDel(
+      key: K,
+      group: K,
+      policy: StreamDeletionPolicy,
+      ids: String*
+  ): F[List[StreamEntryDeletionResult]] =
+    async
+      .flatMap(_.xackdel(key, group, toJStreamDeletionPolicy(policy), ids: _*).futureLift)
+      .map(_.asScala.toList.map(_.asScala))
+
+  override def xNack(key: K, group: K, mode: XNackMode, ids: String*): F[Long] =
+    async.flatMap(_.xnack(key, group, toJXNackMode(mode), ids: _*).futureLift.map(x => Long.box(x)))
+
+  private def toJXNackMode(mode: XNackMode): JXNackMode =
+    mode match {
+      case XNackMode.Silent => JXNackMode.SILENT
+      case XNackMode.Fail   => JXNackMode.FAIL
+      case XNackMode.Fatal  => JXNackMode.FATAL
+    }
 
   override def xClaim(
       key: K,
@@ -3161,6 +3327,17 @@ private[redis4cats] trait RedisConversionOps {
 
   private[redis4cats] implicit class StreamConsumerOps[K](consumer: StreamConsumer[K]) {
     def asJava: JConsumer[K] = JConsumer.from(consumer.group, consumer.consumer)
+  }
+
+  private[redis4cats] implicit class StreamEntryDeletionResultOps(result: JStreamEntryDeletionResult) {
+    def asScala: StreamEntryDeletionResult =
+      result match {
+        case JStreamEntryDeletionResult.DELETED => StreamEntryDeletionResult.Deleted
+        case JStreamEntryDeletionResult.NOT_DELETED_UNACKNOWLEDGED_OR_STILL_REFERENCED =>
+          StreamEntryDeletionResult.NotDeletedUnacknowledgedOrStillReferenced
+        case JStreamEntryDeletionResult.NOT_FOUND => StreamEntryDeletionResult.NotFound
+        case JStreamEntryDeletionResult.UNKNOWN   => StreamEntryDeletionResult.Unknown
+      }
   }
 
   private[redis4cats] implicit class XClaimArgsOps(args: XClaimArgs) {

--- a/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
+++ b/modules/effects/src/main/scala/dev/profunktor/redis4cats/redis.scala
@@ -2949,67 +2949,9 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
     async.flatMap(_.xlen(key).futureLift.map(Long.box(_)))
 
   override def xInfoStream(key: K): F[XStreamInfo[K, V]] =
-    async.flatMap(_.xinfoStream(key).futureLift).flatMap(reply => FutureLift[F].delay(toXStreamInfo(key, reply)))
-
-  // XINFO STREAM comes back from Lettuce as a flat, untyped List[Object]: alternating field-name/value pairs.
-  // first-entry/last-entry are each either null (empty stream) or a nested [id, [field, value, ...]] list - the id
-  // is always a plain String (mirroring core.StreamMessage#getId, which is String regardless of codec), while the
-  // field/value pairs are the actual K/V-decoded message body. Anything beyond the well-known fields (as of Redis
-  // 8.10, a handful of XCFGSET-related idempotency counters) is preserved verbatim in `extra` rather than assumed
-  // away.
-  private val xStreamInfoKnownFields = Set(
-    "length",
-    "radix-tree-keys",
-    "radix-tree-nodes",
-    "last-generated-id",
-    "max-deleted-entry-id",
-    "entries-added",
-    "recorded-first-entry-id",
-    "groups",
-    "first-entry",
-    "last-entry"
-  )
-
-  private def toXStreamInfo(key: K, reply: java.util.List[Object]): XStreamInfo[K, V] = {
-    def fail                 = throw XInfoError.UnexpectedStreamInfoReply(reply.toString)
-    def asLong(a: Any): Long = a.toString.toLong
-
-    def toEntry(raw: Any): StreamMessage[K, V] =
-      raw match {
-        case entry: java.util.List[_] =>
-          entry.asScala.toList match {
-            case (id: String) :: (fields: java.util.List[_]) :: Nil =>
-              val body = fields.asScala.toList
-                .grouped(2)
-                .collect { case (k: Any) :: (v: Any) :: Nil => k.asInstanceOf[K] -> v.asInstanceOf[V] }
-                .toMap
-              StreamMessage(MessageId(id), key, body)
-            case _ => fail
-          }
-        case _ => fail
-      }
-
-    val fields = reply.asScala.toList
-      .grouped(2)
-      .collect { case (name: String) :: value :: Nil => name -> value }
-      .toMap
-
-    def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
-
-    XStreamInfo[K, V](
-      length = required("length")(asLong),
-      radixTreeKeys = required("radix-tree-keys")(asLong),
-      radixTreeNodes = required("radix-tree-nodes")(asLong),
-      lastGeneratedId = required("last-generated-id")(v => MessageId(v.toString)),
-      maxDeletedEntryId = required("max-deleted-entry-id")(v => MessageId(v.toString)),
-      entriesAdded = required("entries-added")(asLong),
-      recordedFirstEntryId = required("recorded-first-entry-id")(v => MessageId(v.toString)),
-      groups = required("groups")(asLong),
-      firstEntry = fields.get("first-entry").flatMap(v => Option(v).map(toEntry)),
-      lastEntry = fields.get("last-entry").flatMap(v => Option(v).map(toEntry)),
-      extra = fields.view.filterKeys(k => !xStreamInfoKnownFields.contains(k)).mapValues(_.toString).toMap
-    )
-  }
+    async
+      .flatMap(_.xinfoStream(key).futureLift)
+      .flatMap(reply => FutureLift[F].delay(XStreamInfo.fromLettuce(key, reply)))
 
   override def xAdd(key: K, body: Map[K, V], args: XAddArgs): F[MessageId] = {
     val jArgs = JXAddArgs.Builder.nomkstream()
@@ -3090,58 +3032,12 @@ private[redis4cats] class BaseRedis[F[_]: FutureLift: MonadThrow: Log, K, V](
   override def xInfoGroups(key: K): F[List[XGroupInfo]] =
     async
       .flatMap(_.xinfoGroups(key).futureLift)
-      .flatMap(reply => FutureLift[F].delay(reply.asScala.toList.map(toXGroupInfo)))
-
-  // Each element of XINFO GROUPS' reply is itself a flat, untyped List[Object] of field-name/value pairs (one per
-  // group) - entries-read/lag are null when Redis can't compute them yet (e.g. right after XGROUP CREATE/XSETID).
-  private def toXGroupInfo(raw: Any): XGroupInfo = {
-    def fail = throw XInfoError.UnexpectedGroupInfoReply(raw.toString)
-    raw match {
-      case entry: java.util.List[_] =>
-        val fields: Map[String, Any] = entry.asScala.toList
-          .grouped(2)
-          .collect { case (name: String) :: value :: Nil => name -> value }
-          .toMap
-        def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
-        def optionalLong(name: String): Option[Long]  = fields.get(name).flatMap(v => Option(v).map(_.toString.toLong))
-        XGroupInfo(
-          name = required("name")(_.toString),
-          consumers = required("consumers")(_.toString.toLong),
-          pending = required("pending")(_.toString.toLong),
-          lastDeliveredId = required("last-delivered-id")(v => MessageId(v.toString)),
-          entriesRead = optionalLong("entries-read"),
-          lag = optionalLong("lag")
-        )
-      case _ => fail
-    }
-  }
+      .flatMap(reply => FutureLift[F].delay(reply.asScala.toList.map(XGroupInfo.fromLettuce)))
 
   override def xInfoConsumers(key: K, group: K): F[List[XConsumerInfo]] =
     async
       .flatMap(_.xinfoConsumers(key, group).futureLift)
-      .flatMap(reply => FutureLift[F].delay(reply.asScala.toList.map(toXConsumerInfo)))
-
-  // Each element of XINFO CONSUMERS' reply is itself a flat, untyped List[Object] of field-name/value pairs (one
-  // per consumer) - `inactive` was added in Redis 7.2, so it's treated as optional for older servers.
-  private def toXConsumerInfo(raw: Any): XConsumerInfo = {
-    def fail = throw XInfoError.UnexpectedConsumerInfoReply(raw.toString)
-    raw match {
-      case entry: java.util.List[_] =>
-        val fields: Map[String, Any] = entry.asScala.toList
-          .grouped(2)
-          .collect { case (name: String) :: value :: Nil => name -> value }
-          .toMap
-        def required[A](name: String)(f: Any => A): A = fields.get(name).map(f).getOrElse(fail)
-        XConsumerInfo(
-          name = required("name")(_.toString),
-          pending = required("pending")(_.toString.toLong),
-          idle = required("idle")(v => FiniteDuration(v.toString.toLong, MILLISECONDS)),
-          inactive =
-            fields.get("inactive").flatMap(v => Option(v).map(v => FiniteDuration(v.toString.toLong, MILLISECONDS)))
-        )
-      case _ => fail
-    }
-  }
+      .flatMap(reply => FutureLift[F].delay(reply.asScala.toList.map(XConsumerInfo.fromLettuce)))
 
   override def xReadGroup(
       consumer: StreamConsumer[K],

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamConsumerGroupSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamConsumerGroupSpec.scala
@@ -149,9 +149,13 @@ class RedisStreamConsumerGroupSpec extends Redis4CatsFunSuite(isCluster = false)
       for {
         _ <- redis.del(key)
         _ <- redis.xGroupCreate(key, group, offset = "0", args = XGroupCreateArgs(mkStream = true))
+        id0 <- redis.xAdd(key, Map("z" -> "0"))
         id1 <- redis.xAdd(key, Map("a" -> "1"))
         id2 <- redis.xAdd(key, Map("b" -> "2"))
         _ <- redis.xReadGroup(c1, XReadOffsets.custom(">", key))
+        // No-policy overload: also defaults to KeepReferences.
+        deletedNoPolicy <- redis.xAckDel(key, group, id0.value)
+        _ <- IO(assertEquals(deletedNoPolicy, List(StreamEntryDeletionResult.Deleted)))
         // KeepReferences (the default): the entry is removed from the stream but XACK still succeeds.
         deleted <- redis.xAckDel(key, group, StreamDeletionPolicy.KeepReferences, id1.value)
         _ <- IO(assertEquals(deleted, List(StreamEntryDeletionResult.Deleted)))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamConsumerGroupSpec.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/RedisStreamConsumerGroupSpec.scala
@@ -102,4 +102,104 @@ class RedisStreamConsumerGroupSpec extends Redis4CatsFunSuite(isCluster = false)
       } yield ()
     }
   }
+
+  test("consumer groups: xInfoGroups and xInfoConsumers") {
+    val key   = "test-cg-info"
+    val group = "test-cg-info-group"
+    val other = "test-cg-info-other-group"
+    val c1    = StreamConsumer(group, "info-consumer-1")
+
+    withRedis { redis =>
+      for {
+        _ <- redis.del(key)
+        _ <- redis.xGroupCreate(key, group, offset = "0", args = XGroupCreateArgs(mkStream = true))
+        _ <- redis.xGroupCreate(key, other, offset = "0")
+        // Fresh group, nothing read yet: no consumers/pending, and entries-read is not yet determinable.
+        freshGroups <- redis.xInfoGroups(key)
+        freshGroup = freshGroups.find(_.name == group).getOrElse(fail(s"group $group not found in $freshGroups"))
+        _ <- IO(assertEquals(freshGroup.consumers, 0L))
+        _ <- IO(assertEquals(freshGroup.pending, 0L))
+        _ <- IO(assertEquals(freshGroup.entriesRead, None))
+        id1 <- redis.xAdd(key, Map("a" -> "1"))
+        _ <- redis.xReadGroup(c1, XReadOffsets.custom(">", key))
+        groupsAfterRead <- redis.xInfoGroups(key)
+        _ <- IO(assertEquals(groupsAfterRead.map(_.name).toSet, Set(group, other)))
+        groupAfterRead = groupsAfterRead.find(_.name == group).getOrElse(fail("group not found"))
+        _ <- IO(assertEquals(groupAfterRead.consumers, 1L))
+        _ <- IO(assertEquals(groupAfterRead.pending, 1L))
+        _ <- IO(assertEquals(groupAfterRead.lastDeliveredId, id1))
+        _ <- IO(assertEquals(groupAfterRead.entriesRead, Some(1L)))
+        consumers <- redis.xInfoConsumers(key, group)
+        _ <- IO(assertEquals(consumers.map(_.name), List("info-consumer-1")))
+        _ <- IO(assertEquals(consumers.head.pending, 1L))
+        _ <- IO(assert(consumers.head.idle >= 0.millis, "idle time should be non-negative"))
+        otherConsumers <- redis.xInfoConsumers(key, other)
+        _ <- IO(assertEquals(otherConsumers, List.empty))
+        _ <- redis.del(key)
+      } yield ()
+    }
+  }
+
+  test("consumer groups: xAckDel acknowledges and deletes in one call") {
+    val key   = "test-cg-ackdel"
+    val group = "test-cg-ackdel-group"
+    val c1    = StreamConsumer(group, "ackdel-consumer")
+
+    withRedis { redis =>
+      for {
+        _ <- redis.del(key)
+        _ <- redis.xGroupCreate(key, group, offset = "0", args = XGroupCreateArgs(mkStream = true))
+        id1 <- redis.xAdd(key, Map("a" -> "1"))
+        id2 <- redis.xAdd(key, Map("b" -> "2"))
+        _ <- redis.xReadGroup(c1, XReadOffsets.custom(">", key))
+        // KeepReferences (the default): the entry is removed from the stream but XACK still succeeds.
+        deleted <- redis.xAckDel(key, group, StreamDeletionPolicy.KeepReferences, id1.value)
+        _ <- IO(assertEquals(deleted, List(StreamEntryDeletionResult.Deleted)))
+        len <- redis.xLen(key)
+        _ <- IO(assertEquals(len, 1L))
+        pendingAfter <- redis.xPending(key, group)
+        _ <- IO(assertEquals(pendingAfter.count, 1L), "id1 should no longer be pending after xAckDel")
+        // Re-running against an id that's already gone reports NotFound rather than failing.
+        deletedAgain <- redis.xAckDel(key, group, StreamDeletionPolicy.KeepReferences, id1.value)
+        _ <- IO(assertEquals(deletedAgain, List(StreamEntryDeletionResult.NotFound)))
+        // DeleteReferences explicitly: same effect as above for a still-pending id, but also clears the PEL entry.
+        deletedWithPolicy <- redis.xAckDel(key, group, StreamDeletionPolicy.DeleteReferences, id2.value)
+        _ <- IO(assertEquals(deletedWithPolicy, List(StreamEntryDeletionResult.Deleted)))
+        pendingFinal <- redis.xPending(key, group)
+        _ <- IO(assertEquals(pendingFinal.count, 0L))
+        _ <- redis.del(key)
+      } yield ()
+    }
+  }
+
+  test("consumer groups: xNack releases a message back to the PEL without acking it") {
+    val key   = "test-cg-nack"
+    val group = "test-cg-nack-group"
+    val c1    = StreamConsumer(group, "nack-consumer")
+
+    withRedis { redis =>
+      for {
+        _ <- redis.del(key)
+        _ <- redis.xGroupCreate(key, group, offset = "0", args = XGroupCreateArgs(mkStream = true))
+        id1 <- redis.xAdd(key, Map("a" -> "1"))
+        _ <- redis.xReadGroup(c1, XReadOffsets.custom(">", key))
+        pendingBefore <- redis.xPending(key, group, XRangePoint.Unbounded, XRangePoint.Unbounded, count = 10L)
+        _ <- IO(assertEquals(pendingBefore.map(_.redeliveryCount), List(1L)))
+        // FAIL leaves the delivery counter unchanged but the message remains pending (not acked/deleted).
+        affected <- redis.xNack(key, group, XNackMode.Fail, id1.value)
+        _ <- IO(assertEquals(affected, 1L))
+        pendingAfterFail <- redis.xPending(key, group, XRangePoint.Unbounded, XRangePoint.Unbounded, count = 10L)
+        _ <- IO(assertEquals(pendingAfterFail.map(_.id), List(id1)))
+        _ <- IO(assertEquals(pendingAfterFail.map(_.redeliveryCount), List(1L)))
+        // SILENT decrements the delivery counter by one.
+        _ <- redis.xNack(key, group, XNackMode.Silent, id1.value)
+        pendingAfterSilent <- redis.xPending(key, group, XRangePoint.Unbounded, XRangePoint.Unbounded, count = 10L)
+        _ <- IO(assertEquals(pendingAfterSilent.map(_.redeliveryCount), List(0L)))
+        // Nacking an id that isn't pending affects nothing.
+        affectedMissing <- redis.xNack(key, group, XNackMode.Fail, "0-1")
+        _ <- IO(assertEquals(affectedMissing, 0L))
+        _ <- redis.del(key)
+      } yield ()
+    }
+  }
 }

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -1785,13 +1785,16 @@ trait TestScenarios { self: FunSuite =>
       _ <- IO(assertEquals(infoAfterCfgSet.extra.get("idmp-maxsize"), Some("500")))
       _ <- IO(assertEquals(infoAfterCfgSet.extra.get("idmp-duration"), Some("60000")))
 
+      // XDELEX no-policy overload (defaults to KeepReferences, matching plain XDEL)
+      delExNoPolicy <- redis.xDelEx("testStream", messageId2.value)
+      _ <- IO(assertEquals(delExNoPolicy, List(StreamEntryDeletionResult.Deleted)))
       // XDELEX - like XDEL, but with control over consumer-group PEL references (irrelevant here, no groups yet)
       delExResult <- redis.xDelEx("testStream", StreamDeletionPolicy.KeepReferences, messageId1.value)
       _ <- IO(assertEquals(delExResult, List(StreamEntryDeletionResult.Deleted)))
       delExMissing <- redis.xDelEx("testStream", StreamDeletionPolicy.KeepReferences, messageId1.value)
       _ <- IO(assertEquals(delExMissing, List(StreamEntryDeletionResult.NotFound)))
       len <- redis.xLen("testStream")
-      _ <- IO(assert(len == 3, "stream should have 3 entries after xdelex"))
+      _ <- IO(assert(len == 2, "stream should have 2 entries after xdelex"))
 
       // Delete from stream
       _ <- redis.xTrim("testStream", XTrimArgs(XTrimArgs.Strategy.MAXLEN(2)))

--- a/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
+++ b/modules/tests/src/test/scala/dev/profunktor/redis4cats/TestScenarios.scala
@@ -1740,9 +1740,10 @@ trait TestScenarios { self: FunSuite =>
       messageId2 <- redis.xAdd("testStream", body = Map("2" -> "b"))
       messageId3 <- redis.xAdd("testStream", body = Map("3" -> "c"))
       messageId4 <- redis.xAdd("testStream", body = Map("4" -> "d"))
+      message1 = StreamMessage(messageId1, "testStream", Map("1" -> "a"))
       message4 = StreamMessage(messageId4, "testStream", Map("4" -> "d"))
       allMessages = List(
-                      StreamMessage(messageId1, "testStream", Map("1" -> "a")),
+                      message1,
                       StreamMessage(messageId2, "testStream", Map("2" -> "b")),
                       StreamMessage(messageId3, "testStream", Map("3" -> "c")),
                       message4
@@ -1769,13 +1770,42 @@ trait TestScenarios { self: FunSuite =>
       messages <- redis.xRead(Set(XReadOffsets.Latest("testStream")))
       _ <- IO(assert(messages.isEmpty, "no messages when reading after the last message"))
 
+      // XINFO STREAM on a non-empty stream
+      info <- redis.xInfoStream("testStream")
+      _ <- IO(assertEquals(info.length, 4L))
+      _ <- IO(assertEquals(info.groups, 0L))
+      _ <- IO(assertEquals(info.lastGeneratedId, messageId4))
+      _ <- IO(assertEquals(info.entriesAdded, 4L))
+      _ <- IO(assertEquals(info.firstEntry, Some(message1)))
+      _ <- IO(assertEquals(info.lastEntry, Some(message4)))
+
+      // XCFGSET - idempotent-publish config takes effect and is reflected back by XINFO STREAM
+      _ <- redis.xCfgSet("testStream", XCfgSetArgs(idempotencyMaxSize = Some(500), idempotencyDuration = Some(60000)))
+      infoAfterCfgSet <- redis.xInfoStream("testStream")
+      _ <- IO(assertEquals(infoAfterCfgSet.extra.get("idmp-maxsize"), Some("500")))
+      _ <- IO(assertEquals(infoAfterCfgSet.extra.get("idmp-duration"), Some("60000")))
+
+      // XDELEX - like XDEL, but with control over consumer-group PEL references (irrelevant here, no groups yet)
+      delExResult <- redis.xDelEx("testStream", StreamDeletionPolicy.KeepReferences, messageId1.value)
+      _ <- IO(assertEquals(delExResult, List(StreamEntryDeletionResult.Deleted)))
+      delExMissing <- redis.xDelEx("testStream", StreamDeletionPolicy.KeepReferences, messageId1.value)
+      _ <- IO(assertEquals(delExMissing, List(StreamEntryDeletionResult.NotFound)))
+      len <- redis.xLen("testStream")
+      _ <- IO(assert(len == 3, "stream should have 3 entries after xdelex"))
+
       // Delete from stream
       _ <- redis.xTrim("testStream", XTrimArgs(XTrimArgs.Strategy.MAXLEN(2)))
       len <- redis.xLen("testStream")
-      _ <- IO(assert(len == 2, "stream should have 3 entries after xtrim"))
+      _ <- IO(assert(len == 2, "stream should have 2 entries after xtrim"))
       _ <- redis.xDel("testStream", messageId3.value, messageId4.value)
       len <- redis.xLen("testStream")
       _ <- IO(assert(len == 0, "stream should have no entries after xdel remaining "))
+
+      // XINFO STREAM on an empty (but existing) stream: first/last entry are absent
+      emptyInfo <- redis.xInfoStream("testStream")
+      _ <- IO(assertEquals(emptyInfo.length, 0L))
+      _ <- IO(assertEquals(emptyInfo.firstEntry, None))
+      _ <- IO(assertEquals(emptyInfo.lastEntry, None))
     } yield ()
 
   def publishAndStatsScenario(redis: RedisCommands[IO, String, String]): IO[Unit] = {


### PR DESCRIPTION
Part of the broader command-coverage audit against Lettuce 7.7.0. `streams.scala` was never audited in that effort until now.

**Added:**
- `xInfoStream`/`xInfoGroups`/`xInfoConsumers` (`XINFO STREAM`/`GROUPS`/`CONSUMERS`) - Lettuce has no `CommandDetailParser`-style utility for these (checked via cellar first), so each hand-rolls a parser over the untyped flat `List[Object]` reply, following the `ReplicationError`/`UnexpectedTimeReply`/`UnexpectedSlowLogEntry` pattern already established for this shape of decode failure. New `XStreamInfo`/`XGroupInfo`/`XConsumerInfo` types plus a new `XInfoError` hierarchy for decode failures. `XStreamInfo` models the well-established fields as named, typed fields, but carries anything else (as of Redis 8.10, a handful of still-new XCFGSET-related idempotency counters: `idmp-duration`, `idmp-maxsize`, `pids-tracked`, `iids-tracked`, `iids-added`, `iids-duplicates`) in an `extra: Map[String, String]` rather than freezing an unstable, undocumented shape into the public type.
- `xDelEx`/`xAckDel` (`XDELEX`/`XACKDEL`) - new native `StreamDeletionPolicy`/`StreamEntryDeletionResult` ADTs wrapping Lettuce's same-named enums (never expose those directly, per the standing design rule from #1193).
- `xNack` (`XNACK`) - new native `XNackMode` ADT wrapping Lettuce's enum. Only the varargs-ids overload is mirrored; Lettuce's single-id overload is redundant with it in Scala (`xNack(key, group, mode, id)` already resolves to the varargs form).
- `xCfgSet` (`XCFGSET`) - new `XCfgSetArgs` case class; returns `F[Unit]` like `configSet` in server.scala, since the wire reply is just a status string.

All four new commands (`XDELEX`/`XACKDEL`/`XNACK`/`XCFGSET`) are very new (Lettuce source dated 2026), so each was verified empirically against a real `redis:8.10.1` container before trusting Lettuce's Java-level support - all four are recognized commands there (`since` 8.2.0-8.8.0 per `COMMAND DOCS`), so nothing was dropped for version-gating this time.

Also confirmed the historical "MAXCOUNT/MAXLEN on XREAD/XREADGROUP" suspicion flagged early in this effort is a non-issue: `xRead`/`xReadGroup` already take a `count: Option[Long]` that maps to `XReadArgs.count`/`maxCount` - no gap there.

**Deliberately out of scope:** nothing was dropped for version-gating this time (see above) - everything Lettuce 7.7.0 exposes for streams is now wrapped.

## Test plan
- [x] `sbt compile` + `Test/compile` - clean
- [x] `sbt mdoc` - clean (`streams.md` documents only the higher-level fs2 `Streaming` API, unaffected by this change)
- [x] `RedisStreamSpec` + `RedisStreamConsumerGroupSpec` green (8/8) against a real `redis:8.10.1` + `yisraelu/redis-cluster:8.10.1` cluster
- [x] `RedisSpec` ("streams api") and `RedisClusterSpec` ("cluster: streams api") green (21/21 and 15/15 respectively), covering the new `xInfoStream`/`xDelEx`/`xCfgSet` assertions added to the shared `streamsScenario`
- [x] New assertions for every method above, including empty-stream and not-found/no-op edge cases